### PR TITLE
add FileViewWidget

### DIFF
--- a/src/widgetRegistry.ts
+++ b/src/widgetRegistry.ts
@@ -6,6 +6,7 @@ import { CalendarWidget } from './widgets/calendarWidget';
 import { RecentNotesWidget } from './widgets/recentNotesWidget';
 import { ThemeSwitcherWidget } from './widgets/themeSwitcherWidget';
 import { TimerStopwatchWidget } from './widgets/timerStopwatchWidget';
+import { FileViewWidget } from './widgets/FileViewWidget';
 
 export const registeredWidgetImplementations: Map<string, new () => WidgetImplementation> = new Map();
 
@@ -16,6 +17,7 @@ registeredWidgetImplementations.set('calendar', CalendarWidget);
 registeredWidgetImplementations.set('recent-notes', RecentNotesWidget);
 registeredWidgetImplementations.set('theme-switcher', ThemeSwitcherWidget);
 registeredWidgetImplementations.set('timer-stopwatch', TimerStopwatchWidget);
+registeredWidgetImplementations.set('file-view-widget', FileViewWidget);
 
 // 新しいウィジェットを追加する場合：
 // 1. src/widgets/に新しいウィジェットファイルを作成 (例: newWidget.ts)

--- a/src/widgets/FileViewWidget.ts
+++ b/src/widgets/FileViewWidget.ts
@@ -1,0 +1,241 @@
+import { App, TFile, Notice, FuzzySuggestModal, MarkdownRenderer } from 'obsidian';
+import type { WidgetConfig, WidgetImplementation } from '../interfaces';
+import type WidgetBoardPlugin from '../main';
+
+// ファイルサジェスト用モーダル
+class FileSuggestModal extends FuzzySuggestModal<TFile> {
+  onChooseCb: (file: TFile) => void;
+  constructor(app: App, private files: TFile[], onChoose: (file: TFile) => void) {
+    super(app);
+    this.onChooseCb = onChoose;
+    this.setPlaceholder('ファイルを検索...');
+  }
+  getItems(): TFile[] {
+    return this.files;
+  }
+  getItemText(item: TFile): string {
+    return item.path;
+  }
+  onChooseItem(item: TFile) {
+    this.onChooseCb(item);
+  }
+}
+
+export class FileViewWidget implements WidgetImplementation {
+  id = 'file-view-widget';
+  private config!: WidgetConfig;
+  private app!: App;
+  private plugin!: WidgetBoardPlugin;
+  private widgetEl!: HTMLElement;
+  private fileContentEl!: HTMLElement;
+  private fileNameInput!: HTMLInputElement;
+  private openButton!: HTMLButtonElement;
+  private selectButton!: HTMLButtonElement;
+  private currentFile: TFile | null = null;
+  private obsidianOpenButton!: HTMLButtonElement;
+  private titleEl!: HTMLElement;
+  // 高さモード: 'auto' or 'fixed'
+  private heightMode: 'auto' | 'fixed' = 'auto';
+  private fixedHeightPx: number = 200;
+
+  create(config: WidgetConfig, app: App, plugin: WidgetBoardPlugin): HTMLElement {
+    this.config = config;
+    this.app = app;
+    this.plugin = plugin;
+
+    // 設定から高さモード・値を初期化
+    this.heightMode = (this.config.settings?.heightMode === 'fixed') ? 'fixed' : 'auto';
+    this.fixedHeightPx = typeof this.config.settings?.fixedHeightPx === 'number' ? this.config.settings.fixedHeightPx : 200;
+
+    // --- カード型ウィジェット本体 ---
+    this.widgetEl = document.createElement('div');
+    this.widgetEl.classList.add('widget', 'file-view-widget');
+    this.widgetEl.setAttribute('data-widget-id', config.id);
+
+    // --- タイトル ---
+    this.titleEl = this.widgetEl.createEl('h4');
+    this.updateTitle();
+
+    // --- カード内コンテンツ ---
+    const contentEl = this.widgetEl.createDiv({ cls: 'widget-content' });
+
+    // --- ボタン類をまとめて上部に配置 ---
+    const controlsEl = contentEl.createDiv({ cls: 'fileview-controls' });
+    controlsEl.style.display = 'flex';
+    controlsEl.style.gap = '8px';
+    controlsEl.style.marginBottom = '8px';
+    controlsEl.style.alignItems = 'center';
+
+    // 編集UI（初期は非表示）
+    this.fileNameInput = document.createElement('input');
+    this.fileNameInput.type = 'text';
+    this.fileNameInput.placeholder = 'ファイルパス';
+    this.fileNameInput.value = this.config.settings?.fileName || '';
+    this.fileNameInput.style.display = 'none';
+    controlsEl.appendChild(this.fileNameInput);
+
+    this.selectButton = document.createElement('button');
+    this.selectButton.textContent = 'ファイル選択';
+    this.selectButton.onclick = () => this.openFileSuggest();
+    this.selectButton.style.display = 'none';
+    controlsEl.appendChild(this.selectButton);
+
+    // Obsidianで開くボタン（常時表示）
+    this.obsidianOpenButton = document.createElement('button');
+    this.obsidianOpenButton.textContent = 'Obsidianで開く';
+    this.obsidianOpenButton.className = 'open-in-obsidian';
+    this.obsidianOpenButton.onclick = () => {
+      if (this.currentFile) {
+        this.app.workspace.openLinkText(this.currentFile.path, '', false);
+      }
+    };
+    controlsEl.appendChild(this.obsidianOpenButton);
+
+    // ファイル内容表示欄
+    this.fileContentEl = contentEl.createDiv({ cls: 'file-content' });
+    this.applyContentHeightStyles();
+
+    // 初期表示
+    this.loadFile();
+
+    // 祖先要素にis-editingクラスが付与されたら編集UIを表示
+    const setupEditModeObserver = () => {
+      const getAncestors = (el: HTMLElement | null): HTMLElement[] => {
+        const ancestors: HTMLElement[] = [];
+        let current = el?.parentElement;
+        while (current) {
+          ancestors.push(current);
+          current = current.parentElement;
+        }
+        return ancestors;
+      };
+      const ancestors = getAncestors(this.widgetEl);
+      if (ancestors.length === 0) {
+        setTimeout(setupEditModeObserver, 100); // まだ親が付与されていない場合は遅延
+        return;
+      }
+      // すべての祖先要素にMutationObserverをセット
+      ancestors.forEach(parent => {
+        const observer = new MutationObserver(() => this.updateEditModeUI());
+        observer.observe(parent, { attributes: true, attributeFilter: ['class'] });
+      });
+      this.updateEditModeUI();
+    };
+    setupEditModeObserver();
+
+    return this.widgetEl;
+  }
+
+  // 編集モードUIの表示/非表示切り替え
+  private updateEditModeUI() {
+    // 祖先要素すべてにis-editingクラスがあるか判定
+    let el: HTMLElement | null = this.widgetEl;
+    let isEditing = false;
+    while (el) {
+      if (el.classList.contains('is-editing')) {
+        isEditing = true;
+        break;
+      }
+      el = el.parentElement;
+    }
+    this.fileNameInput.style.display = isEditing ? '' : 'none';
+    this.selectButton.style.display = isEditing ? '' : 'none';
+  }
+
+  private openFileSuggest() {
+    // .mdファイルのみサジェスト
+    const files = this.app.vault.getFiles().filter(f => f.extension === 'md');
+    new FileSuggestModal(this.app, files, async (file) => {
+      this.fileNameInput.value = file.path;
+      this.config.settings = this.config.settings || {};
+      this.config.settings.fileName = file.path;
+      await this.plugin.saveSettings();
+      this.loadFile();
+      this.updateTitle();
+    }).open();
+  }
+
+  // ファイル内容をレンダリング
+  private async loadFile() {
+    const rawInput = this.config.settings?.fileName?.trim() || '';
+    const fileName = rawInput;
+    this.updateTitle();
+    if (!fileName) {
+      this.fileContentEl.empty();
+      this.fileContentEl.setText('ファイルが選択されていません');
+      this.currentFile = null;
+      return;
+    }
+    // .mdファイル以外はエラー
+    if (!fileName.endsWith('.md')) {
+      this.fileContentEl.empty();
+      this.fileContentEl.setText('Markdown（.md）ファイルのみ表示できます');
+      this.currentFile = null;
+      return;
+    }
+    const file = this.app.vault.getAbstractFileByPath(fileName);
+    if (file instanceof TFile) {
+      this.currentFile = file;
+      const content = await this.app.vault.read(file);
+      this.fileContentEl.empty();
+      await MarkdownRenderer.render(this.app, content, this.fileContentEl, file.path, this.plugin);
+      // 追加: レンダリング後のリンクにクリックイベントを付与
+      this.fileContentEl.querySelectorAll('a').forEach((a: HTMLAnchorElement) => {
+        const href = a.getAttribute('data-href') || a.getAttribute('href');
+        if (href && !href.startsWith('http')) {
+          a.addEventListener('click', (e) => {
+            e.preventDefault();
+            this.app.workspace.openLinkText(href, file.path, false);
+          });
+        }
+      });
+    } else {
+      this.fileContentEl.empty();
+      this.fileContentEl.setText('ファイルが見つかりません');
+      this.currentFile = null;
+    }
+  }
+
+  onunload() {
+    // クリーンアップ処理（必要なら）
+  }
+
+  updateExternalSettings(newSettings: any, widgetId?: string) {
+    // 設定をインスタンスにも反映
+    if (newSettings?.heightMode) {
+      this.heightMode = newSettings.heightMode;
+      this.config.settings.heightMode = newSettings.heightMode;
+    }
+    if (typeof newSettings?.fixedHeightPx === 'number') {
+      this.fixedHeightPx = newSettings.fixedHeightPx;
+      this.config.settings.fixedHeightPx = newSettings.fixedHeightPx;
+    }
+    this.applyContentHeightStyles();
+  }
+
+  // タイトルをファイル名に自動更新
+  private updateTitle() {
+    const fileName = this.config.settings?.fileName;
+    if (fileName && fileName.trim() !== '') {
+      const name = fileName.split(/[\\/]/).pop();
+      this.titleEl.textContent = name || 'ファイルビューア';
+    } else {
+      this.titleEl.textContent = 'ファイルビューア';
+    }
+  }
+
+  // 高さ制御を適用
+  private applyContentHeightStyles() {
+    if (this.heightMode === 'fixed') {
+      this.fileContentEl.style.height = this.fixedHeightPx + 'px';
+      this.fileContentEl.style.minHeight = this.fixedHeightPx + 'px';
+      this.fileContentEl.style.maxHeight = this.fixedHeightPx + 'px';
+      this.fileContentEl.style.overflowY = 'auto';
+    } else {
+      this.fileContentEl.style.height = '';
+      this.fileContentEl.style.minHeight = '80px';
+      this.fileContentEl.style.maxHeight = '';
+      this.fileContentEl.style.overflowY = 'visible';
+    }
+  }
+} 

--- a/styles.css
+++ b/styles.css
@@ -917,3 +917,19 @@ body.wb-modal-open .workspace-leaf-resize-handle {
 .memo-widget-edit-container, .memo-widget-container {
     overflow: visible !important;
 }
+
+/* FileViewWidgetのMarkdownテーブル用スタイル */
+.file-view-widget .file-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 8px 0;
+}
+.file-view-widget .file-content th,
+.file-view-widget .file-content td {
+  border: 1px solid var(--background-modifier-border, #444);
+  padding: 4px 8px;
+  text-align: left;
+}
+.file-view-widget .file-content th {
+  background: var(--background-secondary-alt, #222);
+}


### PR DESCRIPTION
#### 概要
FileViewWidget（ファイルビューア）ウィジェットを追加・改良しました。  
Obsidian内の.mdファイルを選択して内容をカード型で表示できるウィジェットです。

#### 主な変更点
- FileViewWidgetの新規実装
- Obsidian標準のファイルサジェストで.mdファイルのみ選択可能
- 選択したファイルの内容をMarkdownレンダリングで表示
- ウィジェットタイトルに選択中ファイル名を自動表示
- 「Obsidianで開く」ボタンでノートを直接開ける
- 表示エリアの高さを「自動/固定」から設定UIで切り替え可能
- テーブル等のMarkdownも見やすくCSS調整
- 内部リンクもクリックでObsidian内で開ける

#### 補足
- 設定タブから高さモードや固定高さ(px)を調整できます
- コードやUIのご指摘・ご要望があればご指摘ください

---

#### Overview
Added and improved the FileViewWidget (File Viewer) widget.  
This widget allows you to select and display the contents of a .md file in Obsidian as a card.

#### Main Changes
- Implemented new FileViewWidget
- Only .md files can be selected via Obsidian's file suggest modal
- Selected file is rendered as Markdown in the widget
- Widget title automatically shows the selected file name
- "Open in Obsidian" button to open the note directly
- Display area height can be set to "auto" or "fixed" via settings UI
- Improved CSS for Markdown tables and readability
- Internal links in Markdown are clickable and open in Obsidian

#### Notes
- Height mode and fixed height (px) can be adjusted from the settings tab
- Please let me know if you have any feedback or requests

