### PR TITLE
Fix default HTTP method in safeFetch

### DIFF
--- a/src/utils/safeFetch.ts
+++ b/src/utils/safeFetch.ts
@@ -15,12 +15,13 @@ export async function safeFetch(url: string, options: RequestInit = {}): Promise
 
   // ObsidianのrequestUrl APIを利用
   // @ts-ignore
+  const method = options.method?.toUpperCase() || "GET";
   const response = await requestUrl({
     url,
     contentType: "application/json",
     headers: headers as Record<string, string>,
-    method: options.method?.toUpperCase() || "POST",
-    ...( ["POST", "PUT", "PATCH"].includes(options.method?.toUpperCase() || "POST") && { body: options.body?.toString() }),
+    method,
+    ...( ["POST", "PUT", "PATCH"].includes(method) && { body: options.body?.toString() }),
     throw: false,
   });
 


### PR DESCRIPTION
## Summary
- fix default HTTP method in `safeFetch` to use GET when no method is provided

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68406bed73548320b86759bbd87d496b