### PR TITLE
Fix style recalculation by improving containment

### DIFF
--- a/src/modal.ts
+++ b/src/modal.ts
@@ -107,8 +107,10 @@ export class WidgetBoardModal {
         this.contentEl = document.createElement('div');
         this.modalEl.appendChild(this.contentEl);
 
-        // CSS containmentを適用
-        this.modalEl.style.contain = 'layout style';
+        // CSS containmentを適用してレイアウト計算の影響範囲を限定
+        this.modalEl.style.contain = 'layout style paint';
+        // Style recalculation対策として不可視要素はスキップ
+        this.modalEl.style.contentVisibility = 'auto';
     }
 
     /**


### PR DESCRIPTION
## Summary
- refine CSS containment for modal panels to limit layout operations
- enable content visibility so hidden elements don't trigger recalculations

## Testing
- `npm run build` *(fails: Cannot find module 'obsidian')*

------
https://chatgpt.com/codex/tasks/task_e_68406e2bf9708320894079c8e33f1a9e