### PR TITLE
Fix cache size comment

### DIFF
--- a/src/utils/renderMarkdownBatch.ts
+++ b/src/utils/renderMarkdownBatch.ts
@@ -78,7 +78,7 @@ class LRUCache<K, V> {
   }
 }
 
-// 最大100件までキャッシュ
+// 最大1000件までキャッシュ
 const markdownCache = new LRUCache<string, DocumentFragment>(1000);
 
 /**


### PR DESCRIPTION
## Summary
- update comment in `renderMarkdownBatch.ts` to reflect 1000 entries

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68406e622398832089148099ee8272ae