### PR TITLE
Fix Gemini imports

### DIFF
--- a/src/widgets/tweetWidget/aiReply.ts
+++ b/src/widgets/tweetWidget/aiReply.ts
@@ -1,4 +1,4 @@
-import { geminiPrompt } from 'src/llm/gemini/tweetReplyPrompt';
+import { geminiPrompt } from '../../llm/gemini/tweetReplyPrompt';
 import { GeminiProvider } from '../../llm/gemini/geminiApi';
 import { deobfuscate } from '../../utils';
 import type { TweetWidgetPost, AiGovernanceData } from './types'; // AiGovernanceData をインポート

--- a/src/widgets/tweetWidget/tweetWidget.ts
+++ b/src/widgets/tweetWidget/tweetWidget.ts
@@ -3,7 +3,7 @@ import type { WidgetConfig, WidgetImplementation } from '../../interfaces';
 import type WidgetBoardPlugin from '../../main';
 import { GeminiProvider } from '../../llm/gemini/geminiApi';
 import { deobfuscate } from '../../utils';
-import { geminiPrompt } from 'src/llm/gemini/tweetReplyPrompt';
+import { geminiPrompt } from '../../llm/gemini/tweetReplyPrompt';
 
 // --- 分離したモジュールをインポート ---
 import type { TweetWidgetFile, TweetWidgetPost, TweetWidgetSettings } from './types';

--- a/src/widgets/tweetWidget/tweetWidgetUI.ts
+++ b/src/widgets/tweetWidget/tweetWidgetUI.ts
@@ -2,8 +2,8 @@ import { App, Notice, setIcon, MarkdownRenderer, Menu, TFile, Component } from '
 import type { TweetWidget } from './tweetWidget';
 import type { TweetWidgetPost, TweetWidgetFile } from './types';
 import { getFullThreadHistory } from './aiReply';
-import { geminiPrompt } from 'src/llm/gemini/tweetReplyPrompt';
-import { GeminiProvider } from 'src/llm/gemini/geminiApi';
+import { geminiPrompt } from '../../llm/gemini/tweetReplyPrompt';
+import { GeminiProvider } from '../../llm/gemini/geminiApi';
 import { deobfuscate } from '../../utils';
 import { findLatestAiUserIdInThread, generateAiUserId } from './aiReply';
 import { parseLinks, parseTags, extractYouTubeUrl, fetchYouTubeTitle } from './tweetWidgetUtils';


### PR DESCRIPTION
## Summary
- use relative imports for Gemini modules in tweet widget files

## Testing
- `npm run build` *(fails: Cannot find module 'obsidian')*

------
https://chatgpt.com/codex/tasks/task_e_68406e75d5e483209697b961d3f5b0cf