### PR TITLE
Add detailed folder layout

### DIFF
--- a/FILE_STRUCTURE_REVIEW.md
+++ b/FILE_STRUCTURE_REVIEW.md
@@ -1,0 +1,227 @@
+# ファイル構造レビュー
+
+`obsidian-widget-board-plugin` リポジトリの現状の構成を概観し、改善に向けた推奨事項をまとめます。
+
+## 現在の構成
+
+```
+obsidian-widget-board-plugin/
+├── .github/workflows/        # GitHub Actions の設定
+├── src/                      # TypeScript ソースコード
+│   ├── llm/                  # LLM 関連モジュール
+│   ├── settings/             # プラグイン設定
+│   ├── utils/                # ユーティリティ関数
+│   └── widgets/              # 各ウィジェットの実装
+├── logs/                     # ポモドーロのログ
+├── *.md                      # ガイドやドキュメント
+├── styles.css                # プラグインのスタイル
+├── manifest.json             # Obsidian プラグインのマニフェスト
+├── package.json              # Node パッケージ設定
+├── tsconfig.json             # TypeScript コンパイラオプション
+└── esbuild.config.mjs        # ビルド設定
+```
+
+## 詳細フォルダ構成
+
+主要なファイルを含めた、もう少し深い階層を示します。
+
+```
+obsidian-widget-board-plugin/
+├── .github/
+│   └── workflows/
+│       └── release.yml
+├── logs/
+│   └── README.md
+├── src/
+│   ├── interfaces.ts
+│   ├── llm/
+│   │   ├── gemini/
+│   │   │   ├── geminiApi.ts
+│   │   │   ├── prompts.d.ts
+│   │   │   ├── summaryPrompts.ts
+│   │   │   └── tweetReplyPrompt.ts
+│   │   ├── index.ts
+│   │   ├── llmManager.d.ts
+│   │   ├── llmManager.ts
+│   │   └── types.ts
+│   ├── settings/
+│   │   ├── index.ts
+│   │   └── types.ts
+│   ├── utils/
+│   │   ├── index.ts
+│   │   ├── js-yaml.d.ts
+│   │   ├── renderMarkdownBatch.ts
+│   │   ├── safeFetch.ts
+│   │   └── schemaForm.ts
+│   ├── widgets/
+│   │   ├── FileViewWidget.ts
+│   │   ├── calendarWidget.ts
+│   │   ├── memoWidget.ts
+│   │   ├── pomodoroMemoWidget.ts
+│   │   ├── pomodoroWidget.ts
+│   │   ├── recentNotesWidget.ts
+│   │   ├── reflectionWidget/
+│   │   │   ├── constants.ts
+│   │   │   ├── index.ts
+│   │   │   ├── reflectionWidget.ts
+│   │   │   ├── reflectionWidgetTypes.ts
+│   │   │   └── reflectionWidgetUI.ts
+│   │   ├── themeSwitcherWidget.ts
+│   │   ├── timerStopwatchWidget.ts
+│   │   ├── tweetWidget/
+│   │   │   ├── TweetRepository.ts
+│   │   │   ├── TweetStore.ts
+│   │   │   ├── aiReply.ts
+│   │   │   ├── constants.ts
+│   │   │   ├── tweetWidget.md
+│   │   │   ├── tweetWidget.ts
+│   │   │   ├── tweetWidgetAiDb.ts
+│   │   │   ├── tweetWidgetDataViewer.ts
+│   │   │   ├── tweetWidgetUI.ts
+│   │   │   ├── tweetWidgetUtils.ts
+│   │   │   └── types.ts
+│   │   └── types.ts
+│   ├── main.ts
+│   ├── modal.ts
+│   ├── settingsDefaults.ts
+│   ├── settingsTab.ts
+│   └── widgetRegistry.ts
+├── sample.md
+├── styles.css
+├── manifest.json
+├── package.json
+├── package-lock.json
+├── tsconfig.json
+├── version-bump.mjs
+├── versions.json
+└── esbuild.config.mjs
+```
+
+`src/widgets` ディレクトリには `pomodoroWidget.ts` や `memoWidget.ts`、`tweetWidget/` など各ウィジェットのファイル・サブディレクトリが含まれています。`WIDGET_DEV_GUIDE.md` や `WIDGET_PERFORMANCE_GUIDE.md` などのドキュメントはリポジトリのルートに置かれています。
+
+## 推奨事項
+
+1. **ドキュメントの集約** – ガイド類は `docs/` フォルダーにまとめ、ルートを整理する。
+   - `docs/WIDGET_DEV_GUIDE.md`
+   - `docs/WIDGET_PERFORMANCE_GUIDE.md`
+2. **例の配置** – `sample.md` のようなサンプルは `examples/` フォルダーを作ってそこへ移動する。
+3. **ウィジェットフォルダーの統一** – 各ウィジェットを専用フォルダーにまとめ、`widgets/pomodoro/index.ts` や `widgets/memo/index.ts` のように配置する。
+4. **src/ に README を追加** – `src/` 内に簡潔な README を置き、サブフォルダーの目的や新ウィジェットの追加方法を説明する。
+5. **index ファイルの活用** – 各ウィジェットフォルダーで `index.ts` からクラスをエクスポートし、インポートを簡潔に保つ。
+
+これらの変更により保守性が向上し、新しい貢献者もプロジェクトを理解しやすくなります。
+
+---
+
+# File Structure Review
+
+This document provides an overview of the current repository structure of `obsidian-widget-board-plugin` and some recommendations for improvement.
+
+## Current Structure
+
+```
+obsidian-widget-board-plugin/
+├── .github/workflows/        # GitHub Actions workflow
+├── src/                      # TypeScript source code
+│   ├── llm/                  # Large Language Model (LLM) related modules
+│   ├── settings/             # Plugin settings definitions
+│   ├── utils/                # Utility functions
+│   └── widgets/              # Individual widget implementations
+├── logs/                     # Pomodoro log documentation
+├── *.md                      # Guides and documentation
+├── styles.css                # Plugin styles
+├── manifest.json             # Obsidian plugin manifest
+├── package.json              # Node package configuration
+├── tsconfig.json             # TypeScript compiler options
+└── esbuild.config.mjs        # Build configuration
+```
+
+## Detailed Folder Layout
+
+Below is a more complete tree showing notable files.
+
+```
+obsidian-widget-board-plugin/
+├── .github/
+│   └── workflows/
+│       └── release.yml
+├── logs/
+│   └── README.md
+├── src/
+│   ├── interfaces.ts
+│   ├── llm/
+│   │   ├── gemini/
+│   │   │   ├── geminiApi.ts
+│   │   │   ├── prompts.d.ts
+│   │   │   ├── summaryPrompts.ts
+│   │   │   └── tweetReplyPrompt.ts
+│   │   ├── index.ts
+│   │   ├── llmManager.d.ts
+│   │   ├── llmManager.ts
+│   │   └── types.ts
+│   ├── settings/
+│   │   ├── index.ts
+│   │   └── types.ts
+│   ├── utils/
+│   │   ├── index.ts
+│   │   ├── js-yaml.d.ts
+│   │   ├── renderMarkdownBatch.ts
+│   │   ├── safeFetch.ts
+│   │   └── schemaForm.ts
+│   ├── widgets/
+│   │   ├── FileViewWidget.ts
+│   │   ├── calendarWidget.ts
+│   │   ├── memoWidget.ts
+│   │   ├── pomodoroMemoWidget.ts
+│   │   ├── pomodoroWidget.ts
+│   │   ├── recentNotesWidget.ts
+│   │   ├── reflectionWidget/
+│   │   │   ├── constants.ts
+│   │   │   ├── index.ts
+│   │   │   ├── reflectionWidget.ts
+│   │   │   ├── reflectionWidgetTypes.ts
+│   │   │   └── reflectionWidgetUI.ts
+│   │   ├── themeSwitcherWidget.ts
+│   │   ├── timerStopwatchWidget.ts
+│   │   ├── tweetWidget/
+│   │   │   ├── TweetRepository.ts
+│   │   │   ├── TweetStore.ts
+│   │   │   ├── aiReply.ts
+│   │   │   ├── constants.ts
+│   │   │   ├── tweetWidget.md
+│   │   │   ├── tweetWidget.ts
+│   │   │   ├── tweetWidgetAiDb.ts
+│   │   │   ├── tweetWidgetDataViewer.ts
+│   │   │   ├── tweetWidgetUI.ts
+│   │   │   ├── tweetWidgetUtils.ts
+│   │   │   └── types.ts
+│   │   └── types.ts
+│   ├── main.ts
+│   ├── modal.ts
+│   ├── settingsDefaults.ts
+│   ├── settingsTab.ts
+│   └── widgetRegistry.ts
+├── sample.md
+├── styles.css
+├── manifest.json
+├── package.json
+├── package-lock.json
+├── tsconfig.json
+├── version-bump.mjs
+├── versions.json
+└── esbuild.config.mjs
+```
+
+The `src/widgets` directory contains files and subdirectories for each widget (e.g., `pomodoroWidget.ts`, `memoWidget.ts`, `tweetWidget/`). Documentation files such as `WIDGET_DEV_GUIDE.md` and `WIDGET_PERFORMANCE_GUIDE.md` reside in the repository root.
+
+## Recommendations
+
+1. **Group documentation** – Collect all guides under a dedicated `docs/` folder to keep the root tidy. For example:
+   - `docs/WIDGET_DEV_GUIDE.md`
+   - `docs/WIDGET_PERFORMANCE_GUIDE.md`
+2. **Move examples** – Place example markdown like `sample.md` in a new `examples/` directory.
+3. **Consistent widget folders** – Consider placing each widget inside its own folder for better isolation, e.g. `widgets/pomodoro/index.ts`, `widgets/memo/index.ts`.
+4. **Add README to src/** – A short README inside `src/` could explain the purpose of each subfolder and how to add new widgets.
+5. **Use index files** – Export widget classes via `index.ts` files inside each widget folder. This keeps imports shorter and easier to maintain.
+
+These changes can improve maintainability and make it easier for new contributors to navigate the project.


### PR DESCRIPTION
## Summary
- expand `FILE_STRUCTURE_REVIEW.md` with a deeper folder tree in Japanese
- add the same detailed structure in English

## Testing
- `npm run build` *(fails: cannot find modules)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68406cfcfc3c83209f38a725eb93b445