### PR TITLE
Improve modal cleanup performance

### DIFF
--- a/src/modal.ts
+++ b/src/modal.ts
@@ -741,10 +741,14 @@ export class WidgetBoardModal {
         setTimeout(() => {
             this.onClose();
             const selector = `.widget-board-panel-custom[data-board-id='${this.currentBoardId}']`;
-            document.querySelectorAll(selector).forEach(el => {
-                if (el.parentElement === document.body) {
-                    document.body.removeChild(el);
-                }
+            requestAnimationFrame(() => {
+                const fragment = document.createDocumentFragment();
+                document.querySelectorAll(selector).forEach(el => {
+                    if (el.parentElement === document.body) {
+                        fragment.appendChild(el);
+                    }
+                });
+                // dropping the fragment removes the nodes in batch
             });
         }, 300);
         document.body.classList.remove('wb-modal-open');


### PR DESCRIPTION
## Summary
- batch remove leftover board panels using requestAnimationFrame

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68407362e0c88320a6430daf4483e506