### PR TITLE
Add CSS containment for widget container

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2135,7 +2135,8 @@ body.wb-modal-open .workspace-leaf-resize-handle {
 /* --- reflow最適化: CSS Containment --- */
 .widget-content,
 .memo-widget-container,
-.tweet-list-main {
+.tweet-list-main,
+.wb-widget-container {
   contain: layout style paint;
 }
 


### PR DESCRIPTION
## Summary
- add `contain: layout style paint;` to `.wb-widget-container` to limit style recalculations

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684073792ba083208dcb2ce0286c2751