### PR TITLE
Fix widget interface consistency

### DIFF
--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -1,4 +1,4 @@
-import type { WidgetConfig } from '../widgets/types';
+import type { WidgetConfig } from '../interfaces';
 import type { LLMSettings } from '../llm/types';
 
 // --- 個別のボード設定用インターフェース ---

--- a/src/widgets/timerStopwatchWidget.ts
+++ b/src/widgets/timerStopwatchWidget.ts
@@ -1,25 +1,6 @@
 import { App, Notice, setIcon } from 'obsidian';
-
-interface WidgetConfig {
-    id: string;
-    title?: string;
-    settings?: any;
-}
-
-interface WidgetImplementation {
-    id: string;
-    create(config: WidgetConfig, app: App, plugin: WidgetBoardPlugin): HTMLElement;
-    onunload?(): void;
-}
-
-interface WidgetBoardPlugin {
-    manifest: { id: string; [key: string]: any }; // プラグインIDを含むマニフェスト
-    saveSettings: (boardId?: string) => Promise<void>;
-    widgetBoardModals?: Map<string, { isOpen: boolean }>;
-    settings: { lastOpenedBoardId?: string };
-    openWidgetBoardById: (id: string) => void;
-    openBoardPicker: () => void;
-}
+import type { WidgetConfig, WidgetImplementation } from '../interfaces';
+import type WidgetBoardPlugin from '../main';
 
 // --- 通知音の種類の型定義 ---
 export type TimerSoundType = 'off' | 'default_beep' | 'bell' | 'chime'; // chime を追加する場合

--- a/src/widgets/types.ts
+++ b/src/widgets/types.ts
@@ -1,17 +1,1 @@
-import { App } from 'obsidian';
-
-// --- ウィジェット設定のベース ---
-export interface WidgetConfig {
-    id: string;
-    type: string; // 例: 'pomodoro', 'memo', 'tweet-widget', 'reflection-widget' など
-    title: string;
-    settings?: any; // TweetWidgetSettings, ReflectionWidgetSettings なども含む
-}
-
-// --- ウィジェット実装のインターフェース ---
-export interface WidgetImplementation {
-    id: string;
-    create(config: WidgetConfig, app: App, plugin: any): HTMLElement;
-    onunload?(): void;
-    updateExternalSettings?(newSettings: any, widgetId?: string): void;
-} 
+export type { WidgetConfig, WidgetImplementation } from '../interfaces';


### PR DESCRIPTION
## Summary
- keep widget type definitions in one place
- import common interfaces in timerStopwatchWidget
- reference the unified interface from settings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840de04edec832084f74caeeef2780c