### PR TITLE
Optimize markdown rendering cache

### DIFF
--- a/src/utils/renderMarkdownBatch.ts
+++ b/src/utils/renderMarkdownBatch.ts
@@ -37,12 +37,10 @@ export async function renderMarkdownBatch(
   // 3) オフスクリーンdivをbodyから外す（ここでreflowが1回走るが、画面外なので影響最小）
   document.body.removeChild(offscreenDiv);
 
-  // 4) fragmentに全ノードをimportNodeでバッチ化
+  // 4) fragmentに全ノードを直接移動してバッチ化
   const frag = document.createDocumentFragment();
   while (offscreenDiv.firstChild) {
-    const clone = document.importNode(offscreenDiv.firstChild, true);
-    frag.appendChild(clone);
-    offscreenDiv.removeChild(offscreenDiv.firstChild);
+    frag.appendChild(offscreenDiv.firstChild);
   }
 
   // 5) containerに一度だけappendChild（ここでreflowが1回だけ）

--- a/src/utils/renderMarkdownBatch.ts
+++ b/src/utils/renderMarkdownBatch.ts
@@ -123,11 +123,9 @@ export async function renderMarkdownBatchWithCache(
 
   const frag = document.createDocumentFragment();
   while (offscreenDiv.firstChild) {
-    const clone = document.importNode(offscreenDiv.firstChild, true);
-    frag.appendChild(clone);
-    offscreenDiv.removeChild(offscreenDiv.firstChild);
+    frag.appendChild(offscreenDiv.firstChild);
   }
   // キャッシュに保存
   markdownCache.set(markdownText, frag.cloneNode(true) as DocumentFragment);
   container.appendChild(frag);
-} 
+}


### PR DESCRIPTION
## Summary
- optimize DOM node transfer when rendering markdown batches

## Testing
- `npm test --silent` *(fails: Cannot read properties of undefined (reading 'ParseAll'))*

------
https://chatgpt.com/codex/tasks/task_e_6841035315e883209971f27b8aabbc8d