### PR TITLE
Fix modal DOM removal timing

### DIFF
--- a/src/modal.ts
+++ b/src/modal.ts
@@ -756,16 +756,11 @@ export class WidgetBoardModal {
         }
         modalEl.classList.remove('is-open');
         setTimeout(() => {
-            this.onClose();
-            const selector = `.widget-board-panel-custom[data-board-id='${this.currentBoardId}']`;
             requestAnimationFrame(() => {
-                const fragment = document.createDocumentFragment();
-                document.querySelectorAll(selector).forEach(el => {
-                    if (el.parentElement === document.body) {
-                        fragment.appendChild(el);
-                    }
-                });
-                // dropping the fragment removes the nodes in batch
+                this.onClose();
+                if (modalEl.parentElement === document.body) {
+                    document.body.removeChild(modalEl);
+                }
             });
         }, 300);
         document.body.classList.remove('wb-modal-open');


### PR DESCRIPTION
## Summary
- remove board panel DOM directly when modal closes

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'ParseAll'))*

------
https://chatgpt.com/codex/tasks/task_e_68410309652083209f7d39904db48966