### PR TITLE
Optimize Chart.js label rendering

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,36 @@ import { debugLog } from './utils/logger';
 import { Component, TFile } from 'obsidian';
 
 /**
+ * Patch CanvasRenderingContext2D font setter to avoid redundant assignments
+ * which can trigger style recalculations in some browsers.
+ */
+let fontPatchApplied = false;
+function patchCanvasFont(): void {
+    if (fontPatchApplied || typeof CanvasRenderingContext2D === 'undefined') {
+        return;
+    }
+    const desc = Object.getOwnPropertyDescriptor(CanvasRenderingContext2D.prototype, 'font');
+    if (!desc || !desc.get || !desc.set) {
+        return;
+    }
+    const { get, set, enumerable, configurable } = desc;
+    const cache = new WeakMap<CanvasRenderingContext2D, string>();
+    Object.defineProperty(CanvasRenderingContext2D.prototype, 'font', {
+        configurable,
+        enumerable,
+        get() {
+            return get.call(this);
+        },
+        set(value: string) {
+            if (cache.get(this) === value) return;
+            cache.set(this, value);
+            set.call(this, value);
+        }
+    });
+    fontPatchApplied = true;
+}
+
+/**
  * Obsidian Widget Board Pluginのメインクラス
  * - ウィジェットボードの管理・設定・コマンド登録などを担当
  */
@@ -37,6 +67,7 @@ export default class WidgetBoardPlugin extends Plugin {
      */
     async onload(): Promise<void> {
         debugLog(this, 'Widget Board Plugin: Loading...');
+        patchCanvasFont();
         this.llmManager = new LLMManager();
         this.llmManager.register(GeminiProvider);
         await this.loadSettings();

--- a/src/widgets/reflectionWidget/reflectionWidgetUI.ts
+++ b/src/widgets/reflectionWidget/reflectionWidgetUI.ts
@@ -300,7 +300,8 @@ export class ReflectionWidgetUI {
                                         x: {
                                             grid: { display: false },
                                             ticks: {
-                                                maxTicksLimit: 5 // ★ラベル数を最大5件に制限
+                                                maxTicksLimit: 5, // ★ラベル数を最大5件に制限
+                                                sampleSize: 5
                                             }
                                         },
                                         y: { beginAtZero: true, grid: { color: '#eee' } }


### PR DESCRIPTION
## Summary
- patch CanvasRenderingContext2D font setter to avoid redundant assignments
- limit chart tick measurement via `sampleSize`

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'ParseAll'))*

------
https://chatgpt.com/codex/tasks/task_e_6841037c9a888320ad92d9a678a7dd84