### PR TITLE
Fix root folder check in tweet repository

### DIFF
--- a/__tests__/tweetRepositorySave.test.ts
+++ b/__tests__/tweetRepositorySave.test.ts
@@ -1,0 +1,44 @@
+// Mock the obsidian API used in TweetRepository
+jest.mock('obsidian', () => {
+  return {
+    App: class {},
+    Notice: jest.fn(),
+  };
+}, { virtual: true });
+
+import type { TweetWidgetSettings } from '../src/widgets/tweetWidget/types';
+
+let TweetRepository: typeof import('../src/widgets/tweetWidget/TweetRepository.js').TweetRepository;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ TweetRepository } = await import('../src/widgets/tweetWidget/TweetRepository.js'));
+});
+
+describe('TweetRepository.save', () => {
+  const sampleSettings: TweetWidgetSettings = { posts: [] };
+
+  test('does not create folder when path has no folder', async () => {
+    const exists = jest.fn();
+    const mkdir = jest.fn();
+    const write = jest.fn();
+    const app: any = { vault: { adapter: { exists, mkdir, write } } };
+    const repo = new TweetRepository(app, 'tweets.json');
+    await repo.save(sampleSettings);
+    expect(exists).not.toHaveBeenCalled();
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(write).toHaveBeenCalledWith('tweets.json', JSON.stringify(sampleSettings, null, 2));
+  });
+
+  test('creates folder when missing', async () => {
+    const exists = jest.fn().mockResolvedValue(false);
+    const mkdir = jest.fn();
+    const write = jest.fn();
+    const app: any = { vault: { adapter: { exists, mkdir, write } } };
+    const repo = new TweetRepository(app, 'folder/tweets.json');
+    await repo.save(sampleSettings);
+    expect(exists).toHaveBeenCalledWith('folder');
+    expect(mkdir).toHaveBeenCalledWith('folder');
+    expect(write).toHaveBeenCalledWith('folder/tweets.json', JSON.stringify(sampleSettings, null, 2));
+  });
+});

--- a/src/widgets/tweetWidget/TweetRepository.ts
+++ b/src/widgets/tweetWidget/TweetRepository.ts
@@ -69,8 +69,10 @@ export class TweetRepository {
      */
     async save(settings: TweetWidgetSettings): Promise<void> {
         try {
-            const folder = this.dbPath.substring(0, this.dbPath.lastIndexOf('/'));
-            if (!await this.app.vault.adapter.exists(folder)) {
+            const lastSlash = this.dbPath.lastIndexOf('/');
+            const folder = lastSlash !== -1 ? this.dbPath.substring(0, lastSlash) : '';
+            // 'tweets.json' at the vault root requires no directory creation
+            if (folder && !await this.app.vault.adapter.exists(folder)) {
                 await this.app.vault.adapter.mkdir(folder);
             }
             const dataToSave = JSON.stringify(settings, null, 2);


### PR DESCRIPTION
## Summary
- avoid calling mkdir when tweets.json is saved at vault root
- comment about no directory creation for root-level tweets.json
- add tests for TweetRepository.save behavior

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'ParseAll'))*

------
https://chatgpt.com/codex/tasks/task_e_68418678ee50832087931e5d2795bb15