### PR TITLE
Fix manual summary button re-enable

### DIFF
--- a/src/widgets/reflectionWidget/reflectionWidgetUI.ts
+++ b/src/widgets/reflectionWidget/reflectionWidgetUI.ts
@@ -350,13 +350,12 @@ export class ReflectionWidgetUI {
             this.manualBtnEl.onclick = async () => {
                 this.manualBtnEl!.disabled = true;
                 this.manualBtnEl!.innerText = '生成中...';
+                const trigger = () => this.runSummary(true);
                 if ('requestIdleCallback' in window) {
-                    (window as any).requestIdleCallback(() => this.runSummary(true));
+                    (window as any).requestIdleCallback(trigger);
                 } else {
-                    setTimeout(() => this.runSummary(true), 0);
+                    setTimeout(trigger, 0);
                 }
-                this.manualBtnEl!.disabled = false;
-                this.manualBtnEl!.innerText = 'まとめ生成';
             };
             this.aiSummarySectionEl.appendChild(this.manualBtnEl);
         }


### PR DESCRIPTION
## Summary
- keep manual summary button disabled until runSummary completes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68421ff7e4bc8320bba18c58ba2b077b