### PR TITLE
Fix tweet markdown path for image rendering

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,8 @@ import { renderMarkdownBatchWithCache } from './utils/renderMarkdownBatch';
 import { debugLog } from './utils/logger';
 import { Component, TFile } from 'obsidian';
 
+const DEFAULT_TWEET_MD_PATH = 'tweet-widget.md';
+
 /**
  * Obsidian Widget Board Pluginのメインクラス
  * - ウィジェットボードの管理・設定・コマンド登録などを担当
@@ -416,7 +418,7 @@ export default class WidgetBoardPlugin extends Plugin {
                 const tweetEnd = Math.min(tweetIndex + batchSize, tweetPosts.length);
                 for (; tweetIndex < tweetEnd; tweetIndex++) {
                     const post = tweetPosts[tweetIndex];
-                    await renderMarkdownBatchWithCache(post.text, document.createElement('div'), '', new Component());
+                    await renderMarkdownBatchWithCache(post.text, document.createElement('div'), DEFAULT_TWEET_MD_PATH, new Component());
                 }
                 // MemoWidget
                 const memoEnd = Math.min(memoIndex + batchSize, memoContents.length);

--- a/src/widgets/tweetWidget/tweetWidgetUI.ts
+++ b/src/widgets/tweetWidget/tweetWidgetUI.ts
@@ -10,6 +10,8 @@ import { parseLinks, parseTags, extractYouTubeUrl, fetchYouTubeTitle } from './t
 import { TweetWidgetDataViewer } from './tweetWidgetDataViewer';
 import { renderMarkdownBatchWithCache } from '../../utils/renderMarkdownBatch';
 
+const DEFAULT_TWEET_MD_PATH = 'tweet-widget.md';
+
 // グローバルで再計算が必要な要素を管理
 const pendingTweetResizeElements: HTMLTextAreaElement[] = [];
 let scheduledTweetResize = false;
@@ -330,7 +332,8 @@ export class TweetWidgetUI {
                 previewArea.style.display = '';
                 input.style.display = 'none';
                 previewArea.empty();
-                await renderMarkdownBatchWithCache(input.value, previewArea, this.app.workspace.getActiveFile()?.path || '', new Component());
+                const srcPath = this.app.workspace.getActiveFile()?.path || DEFAULT_TWEET_MD_PATH;
+                await renderMarkdownBatchWithCache(input.value, previewArea, srcPath, new Component());
             } else {
                 previewArea.style.display = 'none';
                 input.style.display = '';
@@ -651,7 +654,8 @@ export class TweetWidgetUI {
             const parsed = JSON.parse(displayText);
             if (parsed && typeof parsed.reply === 'string') displayText = parsed.reply;
         } catch {}
-        await renderMarkdownBatchWithCache(displayText, textDiv, this.app.workspace.getActiveFile()?.path || '', new Component());
+        const srcPath2 = this.app.workspace.getActiveFile()?.path || DEFAULT_TWEET_MD_PATH;
+        await renderMarkdownBatchWithCache(displayText, textDiv, srcPath2, new Component());
 
         if (post.files && post.files.length) {
             const filesDiv = item.createDiv({ cls: `tweet-item-files-main files-count-${post.files.length}` });


### PR DESCRIPTION
## Summary
- ensure tweet widget renders images correctly by providing a fallback source path
- prewarm cache with same path for tweet posts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684230e217d483208063084cf72190e8