### PR TITLE
Fix optional title element access

### DIFF
--- a/src/widgets/theme-switcher/index.ts
+++ b/src/widgets/theme-switcher/index.ts
@@ -38,7 +38,9 @@ export class ThemeSwitcherWidget implements WidgetImplementation {
 
         const { widgetEl, titleEl } = createWidgetContainer(config, 'theme-switcher-widget');
         this.widgetEl = widgetEl;
-        titleEl.textContent = this.config.title?.trim() || 'テーマ切り替え';
+        if (titleEl) {
+            titleEl.textContent = this.config.title?.trim() || 'テーマ切り替え';
+        }
 
         const contentEl = this.widgetEl.createDiv({ cls: 'widget-content' });
         this.renderThemeSelector(contentEl);


### PR DESCRIPTION
## Summary
- handle missing title element in theme-switcher widget

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843a63c53f4832085be88b888986330