### PR TITLE
Remove placeholder comments

### DIFF
--- a/docs/WIDGET_DEV_GUIDE.md
+++ b/docs/WIDGET_DEV_GUIDE.md
@@ -405,7 +405,6 @@ private static widgetStates: Map<string, any> = new Map();
 
 ### - **YAMLで大きさ指定が可能なサンプル**
   ```ts
-  // ...既存コード...
   // 追加: YAMLで大きさ指定があれば反映
   const settings = (config.settings || {}) as any;
   if (settings.width) this.widgetEl.style.width = settings.width;

--- a/src/widgets/recent-notes/index.ts
+++ b/src/widgets/recent-notes/index.ts
@@ -30,7 +30,7 @@ export class RecentNotesWidget implements WidgetImplementation {
      * インスタンス初期化
      */
     constructor() {
-        // ... 既存コード ...
+        // no initialization required
     }
 
     /**

--- a/src/widgets/theme-switcher/index.ts
+++ b/src/widgets/theme-switcher/index.ts
@@ -22,7 +22,7 @@ export class ThemeSwitcherWidget implements WidgetImplementation {
      * インスタンス初期化
      */
     constructor() {
-        // ... 既存コード ...
+        // no initialization needed
     }
 
     /**

--- a/src/widgets/timer-stopwatch/index.ts
+++ b/src/widgets/timer-stopwatch/index.ts
@@ -72,7 +72,7 @@ export class TimerStopwatchWidget implements WidgetImplementation {
      * インスタンス初期化
      */
     constructor() {
-        // ... 既存コード ...
+        // no initialization logic
     }
 
     private getInternalState(): TimerStopwatchState | undefined {
@@ -560,6 +560,31 @@ export class TimerStopwatchWidget implements WidgetImplementation {
      * @param widgetId 対象ウィジェットID
      */
     public async updateExternalSettings(newSettings: Partial<TimerStopwatchWidgetSettings>, widgetId?: string) {
-        // ... 既存コード ...
+        if (widgetId && this.config.id !== widgetId) return;
+
+        const before = { ...this.currentSettings };
+        this.currentSettings = { ...this.currentSettings, ...newSettings };
+
+        if (this.config && this.config.settings) {
+            Object.assign(this.config.settings, this.currentSettings);
+        }
+
+        const mins = this.currentSettings.timerMinutes ?? before.timerMinutes ?? 0;
+        const secs = this.currentSettings.timerSeconds ?? before.timerSeconds ?? 0;
+        const total = mins * 60 + secs;
+
+        const state = TimerStopwatchWidget.widgetStates.get(this.config.id);
+        if (state) {
+            state.initialTimerSeconds = total;
+            if (!state.running && state.mode === 'timer') {
+                state.remainingSeconds = total;
+            }
+            TimerStopwatchWidget.widgetStates.set(this.config.id, state);
+        }
+
+        if (this.timerMinInput) this.timerMinInput.value = String(mins);
+        if (this.timerSecInput) this.timerSecInput.value = String(secs);
+
+        this.updateDisplay();
     }
 }


### PR DESCRIPTION
## Summary
- implement no-op constructors for timer-stopwatch, theme-switcher and recent-notes widgets
- flesh out `updateExternalSettings` in timer-stopwatch widget so external configuration updates sync with UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843a7f56be483209eb179a8a166f9c5