### PR TITLE
Fix pomodoro timer display flicker on board reopen

### DIFF
--- a/src/widgets/pomodoro/index.ts
+++ b/src/widgets/pomodoro/index.ts
@@ -359,6 +359,8 @@ export class PomodoroWidget implements WidgetImplementation {
             this.pomodorosCompletedInCycle = state.pomodorosCompletedInCycle;
         }
         PomodoroWidget.ensureGlobalInterval();
+        // Immediately reflect restored state to avoid flicker when reopening boards
+        this.updateDisplay();
 
         this.initialized = true;
         this.lastConfiguredId = newConfigId;


### PR DESCRIPTION
## Summary
- update pomodoro timer display right after restoring state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843aa9bb30483208f912f9ef67eea45