### PR TITLE
Enable quote retweet modal for tweet widget

### DIFF
--- a/src/widgets/tweetWidget/TweetStore.ts
+++ b/src/widgets/tweetWidget/TweetStore.ts
@@ -31,6 +31,13 @@ export class TweetStore {
                 parent.updated = Date.now();
             }
         }
+        if (post.quoteId) {
+            const target = this.postsById.get(post.quoteId);
+            if (target) {
+                target.retweet = (target.retweet || 0) + 1;
+                target.updated = Date.now();
+            }
+        }
         this.updatePostsById();
     }
 
@@ -60,6 +67,12 @@ export class TweetStore {
                 parent.replyCount = Math.max(0, (parent.replyCount || 0) - 1);
             }
         }
+        if (post?.quoteId) {
+            const target = this.postsById.get(post.quoteId);
+            if (target) {
+                target.retweet = Math.max(0, (target.retweet || 0) - 1);
+            }
+        }
         this.settings.posts = this.settings.posts.filter(p => p.id !== postId);
         this.updatePostsById();
     }
@@ -78,7 +91,17 @@ export class TweetStore {
                 parent.replyCount = Math.max(0, (parent.replyCount || 0) - 1);
             }
         }
-        
+
+        for (const id of threadIds) {
+            const p = this.postsById.get(id);
+            if (p?.quoteId) {
+                const target = this.postsById.get(p.quoteId);
+                if (target) {
+                    target.retweet = Math.max(0, (target.retweet || 0) - 1);
+                }
+            }
+        }
+
         this.settings.posts = this.settings.posts.filter(p => !threadIds.includes(p.id));
         this.updatePostsById();
     }

--- a/src/widgets/tweetWidget/tweetWidget.ts
+++ b/src/widgets/tweetWidget/tweetWidget.ts
@@ -150,9 +150,7 @@ export class TweetWidget implements WidgetImplementation {
 
     public async submitRetweet(text: string, target: TweetWidgetPost) {
         const trimmedText = text.trim();
-        const quote = '> ' + target.text.replace(/\n/g, '\n> ');
-        const finalText = trimmedText ? `${trimmedText}\n\n${quote}` : quote;
-        const newPost = this.createNewPostObject(finalText, null, target.id);
+        const newPost = this.createNewPostObject(trimmedText, null, target.id);
         this.store.addPost(newPost);
         const count = this.getQuoteCount(target.id);
         this.store.updatePost(target.id, {

--- a/src/widgets/tweetWidget/tweetWidget.ts
+++ b/src/widgets/tweetWidget/tweetWidget.ts
@@ -34,6 +34,7 @@ export class TweetWidget implements WidgetImplementation {
     detailPostId: string | null = null;
     replyModalPost: TweetWidgetPost | null = null;
     retweetModalPost: TweetWidgetPost | null = null;
+    retweetListPost: TweetWidgetPost | null = null;
     currentTab: 'home' | 'notification' = 'home';
     currentPeriod: string = 'all';
     customPeriodDays: number = 1;
@@ -150,7 +151,7 @@ export class TweetWidget implements WidgetImplementation {
         const trimmedText = text.trim();
         const quote = '> ' + target.text.replace(/\n/g, '\n> ');
         const finalText = trimmedText ? `${trimmedText}\n\n${quote}` : quote;
-        const newPost = this.createNewPostObject(finalText);
+        const newPost = this.createNewPostObject(finalText, null, target.id);
         this.store.addPost(newPost);
         this.store.updatePost(target.id, {
             retweet: (target.retweet || 0) + 1,
@@ -161,7 +162,7 @@ export class TweetWidget implements WidgetImplementation {
         this.ui.render();
     }
     
-    private createNewPostObject(text: string, threadId: string | null = this.replyingToParentId): TweetWidgetPost {
+    private createNewPostObject(text: string, threadId: string | null = this.replyingToParentId, quoteId: string | null = null): TweetWidgetPost {
         return {
             id: 'tw-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8),
             text,
@@ -176,6 +177,7 @@ export class TweetWidget implements WidgetImplementation {
             deleted: false,
             bookmark: false,
             threadId: threadId,
+            quoteId,
             visibility: 'public',
             noteQuality: 'fleeting',
             taskStatus: null,
@@ -251,6 +253,7 @@ export class TweetWidget implements WidgetImplementation {
     public startReply(post: TweetWidgetPost) {
         this.replyModalPost = post;
         this.retweetModalPost = null;
+        this.retweetListPost = null;
         this.editingPostId = null;
         this.replyingToParentId = null;
         this.ui.render();
@@ -264,6 +267,7 @@ export class TweetWidget implements WidgetImplementation {
     public startRetweet(post: TweetWidgetPost) {
         this.retweetModalPost = post;
         this.replyModalPost = null;
+        this.retweetListPost = null;
         this.editingPostId = null;
         this.replyingToParentId = null;
         this.ui.render();
@@ -271,6 +275,20 @@ export class TweetWidget implements WidgetImplementation {
 
     public cancelRetweet() {
         this.retweetModalPost = null;
+        this.ui.render();
+    }
+
+    public openRetweetList(post: TweetWidgetPost) {
+        this.retweetListPost = post;
+        this.replyModalPost = null;
+        this.retweetModalPost = null;
+        this.editingPostId = null;
+        this.replyingToParentId = null;
+        this.ui.render();
+    }
+
+    public closeRetweetList() {
+        this.retweetListPost = null;
         this.ui.render();
     }
 

--- a/src/widgets/tweetWidget/tweetWidgetUI.ts
+++ b/src/widgets/tweetWidget/tweetWidgetUI.ts
@@ -615,7 +615,12 @@ export class TweetWidgetUI {
         };
     }
 
-    private async renderSinglePost(post: TweetWidgetPost, container: HTMLElement, isDetail: boolean = false): Promise<void> {
+    private async renderSinglePost(
+        post: TweetWidgetPost,
+        container: HTMLElement,
+        isDetail: boolean = false,
+        isQuoteEmbed: boolean = false
+    ): Promise<void> {
         container.empty();
         const item = container.createDiv({ cls: 'tweet-item-main' });
         
@@ -704,7 +709,7 @@ export class TweetWidgetUI {
                         (e.target as HTMLElement).closest('.tweet-item-avatar-main')) return;
                     this.widget.navigateToDetail(quoted.id);
                 };
-                await this.renderSinglePost(quoted, quoteWrap, true);
+                await this.renderSinglePost(quoted, quoteWrap, true, true);
             }
         }
 
@@ -733,7 +738,9 @@ export class TweetWidgetUI {
             });
         }
 
-        this.renderActionBar(item, post);
+        if (!isQuoteEmbed) {
+            this.renderActionBar(item, post);
+        }
         
         if (!isDetail) {
             this.renderReactedUsers(item, post);

--- a/src/widgets/tweetWidget/tweetWidgetUI.ts
+++ b/src/widgets/tweetWidget/tweetWidgetUI.ts
@@ -657,6 +657,12 @@ export class TweetWidgetUI {
             const parsed = JSON.parse(displayText);
             if (parsed && typeof parsed.reply === 'string') displayText = parsed.reply;
         } catch {}
+        if (post.quoteId) {
+            displayText = displayText
+                .split('\n')
+                .filter(line => !/^>\s?/.test(line.trim()))
+                .join('\n');
+        }
 
         // --- 画像Markdown記法のパスを置換 ---
         let replacedText = displayText;

--- a/src/widgets/tweetWidget/tweetWidgetUI.ts
+++ b/src/widgets/tweetWidget/tweetWidgetUI.ts
@@ -695,6 +695,19 @@ export class TweetWidgetUI {
             img.style.display = 'block';
         });
 
+        if (post.quoteId) {
+            const quoted = this.postsById.get(post.quoteId);
+            if (quoted) {
+                const quoteWrap = item.createDiv({ cls: 'tweet-quote-container' });
+                quoteWrap.onclick = (e) => {
+                    if ((e.target as HTMLElement).closest('.tweet-action-bar-main') ||
+                        (e.target as HTMLElement).closest('.tweet-item-avatar-main')) return;
+                    this.widget.navigateToDetail(quoted.id);
+                };
+                await this.renderSinglePost(quoted, quoteWrap, true);
+            }
+        }
+
         const metadataDiv = item.createDiv({ cls: 'tweet-item-metadata-main' });
         if (post.bookmark) metadataDiv.createEl('span', { cls: 'tweet-chip bookmark', text: 'Bookmarked' });
         if (post.visibility && post.visibility !== 'public') metadataDiv.createEl('span', { cls: 'tweet-chip visibility', text: post.visibility });
@@ -736,7 +749,8 @@ export class TweetWidgetUI {
             this.widget.startReply(post);
         };
         
-        const rtBtn = this.createActionButton(actionBar, 'repeat-2', post.retweet, 'retweet', post.retweeted);
+        const quoteCount = this.widget.getQuoteCount(post.id);
+        const rtBtn = this.createActionButton(actionBar, 'repeat-2', quoteCount, 'retweet', post.retweeted);
         rtBtn.onclick = (e) => { e.stopPropagation(); this.showRetweetMenu(e, post); };
 
         const likeBtn = this.createActionButton(actionBar, 'heart', post.like, 'like', post.liked);
@@ -1058,7 +1072,16 @@ export class TweetWidgetUI {
         if (retweets.length === 0) {
             listBox.createDiv({ text: 'まだ引用リツイートはありません。', cls: 'tweet-empty-notice' });
         } else {
-            retweets.forEach(rt => this.renderSinglePost(rt, listBox, true));
+            retweets.forEach(rt => {
+                const wrapper = listBox.createDiv({ cls: 'tweet-quote-list-item' });
+                wrapper.onclick = (e) => {
+                    if ((e.target as HTMLElement).closest('.tweet-action-bar-main') ||
+                        (e.target as HTMLElement).closest('.tweet-item-avatar-main')) return;
+                    closeModal();
+                    this.widget.navigateToDetail(rt.id);
+                };
+                this.renderSinglePost(rt, wrapper, true);
+            });
         }
     }
 

--- a/src/widgets/tweetWidget/tweetWidgetUtils.ts
+++ b/src/widgets/tweetWidget/tweetWidgetUtils.ts
@@ -58,6 +58,7 @@ export function validatePost(raw: any): TweetWidgetPost {
         retweeted: !!raw.retweeted,
         edited: !!raw.edited,
         replyCount: typeof raw.replyCount === 'number' ? raw.replyCount : 0,
+        quoteId: typeof raw.quoteId === 'string' ? raw.quoteId : null,
         deleted: !!raw.deleted,
         bookmark: !!raw.bookmark,
         contextNote: typeof raw.contextNote === 'string' ? raw.contextNote : null,

--- a/src/widgets/tweetWidget/types.ts
+++ b/src/widgets/tweetWidget/types.ts
@@ -23,6 +23,8 @@ export interface TweetWidgetPost {
     retweeted?: boolean;
     edited?: boolean;
     replyCount?: number;
+    /** 引用リツイート元の投稿ID */
+    quoteId?: string | null;
 
     // PKM（個人知識管理）フィールド
     tags?: string[];

--- a/styles.css
+++ b/styles.css
@@ -1291,6 +1291,16 @@ body.wb-modal-open .workspace-leaf-resize-handle {
   margin: 16px 0;
   font-size: 0.98em;
 }
+
+.tweet-quote-container {
+  margin-top: 8px;
+  padding-left: 12px;
+  border-left: 2px solid var(--background-modifier-border, #444);
+}
+
+.tweet-quote-list-item {
+  margin-bottom: 12px;
+}
 .tweet-action-bar-main {
   display: flex;
   gap: 16px;


### PR DESCRIPTION
## Summary
- open a modal for quote retweets instead of directly toggling
- implement `startRetweet` and `submitRetweet` logic
- add UI to handle retweet modal and call new actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843b6b26ab483209661f90cd916a6ec