### PR TITLE
Fix tests by adding jest mocks and setup

### DIFF
--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -1,0 +1,36 @@
+export class App {}
+export class Component {}
+export class TFile { path = ''; basename = ''; extension = ''; stat = { mtime: 0 }; }
+export class TFolder { path = ''; }
+export class Modal {}
+export class Notice { constructor(public message?: string) {} }
+export const MarkdownRenderer = {
+  renderMarkdown: jest.fn((md: string, el: HTMLElement) => {
+    el.innerHTML = `<p>${md}</p>`;
+    return Promise.resolve();
+  }),
+};
+export function createEl(tag: string, opts: any = {}, parent?: HTMLElement): HTMLElement {
+  const el = document.createElement(tag);
+  if (opts.cls) el.className = opts.cls;
+  if (opts.text) el.textContent = opts.text;
+  if (opts.type) el.setAttribute('type', opts.type);
+  if (opts.attr) {
+    for (const [k, v] of Object.entries(opts.attr)) {
+      el.setAttribute(k, String(v));
+    }
+  }
+  if (parent) parent.appendChild(el);
+  return el;
+}
+export function createSpan(opts: any = {}, parent?: HTMLElement): HTMLElement {
+  return createEl('span', opts, parent);
+}
+export function setIcon(el: HTMLElement | null, icon: string): void {
+  if (el) { (el as any).dataset.icon = icon; }
+}
+export function requestUrl(_opts: any): Promise<any> {
+  return Promise.resolve({ status: 200, text: '', json: {} });
+}
+export class FuzzySuggestModal {}
+export const debounce = (fn: any) => fn;

--- a/__tests__/tweetWidget.test.ts
+++ b/__tests__/tweetWidget.test.ts
@@ -8,7 +8,13 @@ describe('TweetWidget', () => {
     title: 'テストツイート',
     settings: { posts: [], userId: '@test', userName: 'テスト', verified: false }
   };
-  const dummyApp = { vault: { adapter: { exists: jest.fn(), mkdir: jest.fn(), read: jest.fn(), write: jest.fn() } } } as any;
+  const dummyApp = {
+    vault: {
+      adapter: { exists: jest.fn(), mkdir: jest.fn(), read: jest.fn(), write: jest.fn() },
+      getFiles: jest.fn(() => []),
+    },
+    workspace: { getActiveFile: jest.fn(() => ({ path: 'active.md' })) },
+  } as any;
   const dummyPlugin = { settings: { defaultTweetPeriod: 'all', defaultTweetCustomDays: 1 }, manifest: { id: 'test-plugin' } } as any;
 
   it('createメソッドでHTMLElementを返す', () => {
@@ -20,6 +26,7 @@ describe('TweetWidget', () => {
   it('switchTabでcurrentTabが切り替わる', async () => {
     const widget = new TweetWidget();
     widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await new Promise(res => setTimeout(res, 0));
     await widget.switchTab('notification');
     expect(widget.currentTab).toBe('notification');
   });
@@ -27,13 +34,17 @@ describe('TweetWidget', () => {
   it('setFilterでcurrentFilterが切り替わる', () => {
     const widget = new TweetWidget();
     widget.create(dummyConfig, dummyApp, dummyPlugin);
-    widget.setFilter('bookmark');
-    expect(widget.currentFilter).toBe('bookmark');
+    // wait for async init
+    return Promise.resolve().then(() => new Promise(res => setTimeout(res, 0))).then(() => {
+      widget.setFilter('bookmark');
+      expect(widget.currentFilter).toBe('bookmark');
+    });
   });
 
   it('submitPostで投稿が追加される', async () => {
     const widget = new TweetWidget();
     widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('テスト投稿');
     expect(widget.currentSettings.posts.length).toBeGreaterThan(0);
   });
@@ -41,6 +52,7 @@ describe('TweetWidget', () => {
   it('submitReplyで返信が追加される', async () => {
     const widget = new TweetWidget();
     widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await new Promise(res => setTimeout(res, 0));
     await widget.submitReply('返信テスト', 'parent-id');
     expect(widget.currentSettings.posts.length).toBeGreaterThan(0);
   });
@@ -48,6 +60,7 @@ describe('TweetWidget', () => {
   it('toggleLikeでlikedが切り替わる', async () => {
     const widget = new TweetWidget();
     widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('いいねテスト');
     const postId = widget.currentSettings.posts[0].id;
     await widget.toggleLike(postId);

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,8 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': '<rootDir>/jest.transform.js',
   },
+  moduleNameMapper: {
+    '^obsidian$': '<rootDir>/__mocks__/obsidian.ts',
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,74 @@
+if (typeof HTMLElement !== 'undefined') {
+  if (!HTMLElement.prototype.empty) {
+    HTMLElement.prototype.empty = function () {
+      while (this.firstChild) this.removeChild(this.firstChild);
+    };
+  }
+  if (!HTMLElement.prototype.createDiv) {
+    HTMLElement.prototype.createDiv = function (opts = {}) {
+      const el = document.createElement('div');
+      if (opts.cls) el.className = opts.cls;
+      if (opts.text) el.textContent = opts.text;
+      this.appendChild(el);
+      return el;
+    };
+  }
+  if (!HTMLElement.prototype.createEl) {
+    HTMLElement.prototype.createEl = function (tag, opts = {}) {
+      const el = document.createElement(tag);
+      if (opts.cls) el.className = opts.cls;
+      if (opts.text) el.textContent = opts.text;
+      this.appendChild(el);
+      return el;
+    };
+  }
+  if (!HTMLElement.prototype.createSpan) {
+    HTMLElement.prototype.createSpan = function (opts = {}) {
+      return this.createEl('span', opts);
+    };
+  }
+  if (!HTMLElement.prototype.onClickEvent) {
+    HTMLElement.prototype.onClickEvent = function (callback) {
+      this.addEventListener('click', callback);
+    };
+  }
+  if (!HTMLElement.prototype.setText) {
+    HTMLElement.prototype.setText = function (text) {
+      this.textContent = text;
+    };
+  }
+  if (!HTMLElement.prototype.addClass) {
+    HTMLElement.prototype.addClass = function (cls) {
+      this.classList.add(cls);
+    };
+  }
+  if (!HTMLElement.prototype.setAttr) {
+    HTMLElement.prototype.setAttr = function (name, value) {
+      this.setAttribute(name, value);
+    };
+  }
+}
+
+// Stub AudioContext for environments without Web Audio API
+if (typeof window !== 'undefined' && typeof window.AudioContext === 'undefined') {
+  class FakeAudioContext {
+    constructor() { this.currentTime = 0; this.state = 'running'; }
+    createOscillator() { return { connect() {}, type: 'sine', frequency: { setValueAtTime() {} }, start() {}, stop() {}, onended: null }; }
+    createGain() { return { gain: { setValueAtTime() {}, exponentialRampToValueAtTime() {} }, connect() {} }; }
+    close() { return Promise.resolve(); }
+    get destination() { return {}; }
+  }
+  // @ts-ignore
+  window.AudioContext = FakeAudioContext;
+  // @ts-ignore
+  window.webkitAudioContext = FakeAudioContext;
+}
+
+// Expose createEl and createSpan globally for code that expects them
+try {
+  const obsidian = require('./__mocks__/obsidian.ts');
+  if (typeof global !== 'undefined') {
+    global.createEl = obsidian.createEl;
+    global.createSpan = obsidian.createSpan;
+  }
+} catch {}


### PR DESCRIPTION
## Summary
- add manual mock for `obsidian` to make unit tests work
- configure Jest to use the mock and setup file
- provide DOM helpers and stubs in `jest.setup.js`
- update tweetWidget tests to wait for async init and mock workspace

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843e9091ef083208645df116bd8353b