### PR TITLE
Improve ReflectionWidget performance

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { TweetRepository } from './widgets/tweetWidget/TweetRepository';
 import { renderMarkdownBatchWithCache } from './utils/renderMarkdownBatch';
 import { debugLog } from './utils/logger';
 import { Component, TFile } from 'obsidian';
+import { preloadChartJS } from './widgets/reflectionWidget/reflectionWidgetUI';
 
 /**
  * Obsidian Widget Board Pluginのメインクラス
@@ -39,8 +40,8 @@ export default class WidgetBoardPlugin extends Plugin {
         debugLog(this, 'Widget Board Plugin: Loading...');
         this.llmManager = new LLMManager();
         this.llmManager.register(GeminiProvider);
-        // Preload Chart.js for ReflectionWidget to avoid first render delay
-        import('chart.js/auto').catch(() => {});
+        // Preload Chart.js for ReflectionWidget without blocking startup
+        setTimeout(() => preloadChartJS().catch(() => {}), 0);
         await this.loadSettings();
         this.registerAllBoardCommands();
         this.addRibbonIcon('layout-dashboard', 'ウィジェットボードを開く', () => this.openBoardPicker());

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,8 @@ export default class WidgetBoardPlugin extends Plugin {
         debugLog(this, 'Widget Board Plugin: Loading...');
         this.llmManager = new LLMManager();
         this.llmManager.register(GeminiProvider);
+        // Preload Chart.js for ReflectionWidget to avoid first render delay
+        import('chart.js/auto').catch(() => {});
         await this.loadSettings();
         this.registerAllBoardCommands();
         this.addRibbonIcon('layout-dashboard', 'ウィジェットボードを開く', () => this.openBoardPicker());

--- a/src/widgets/reflectionWidget/reflectionWidgetUI.ts
+++ b/src/widgets/reflectionWidget/reflectionWidgetUI.ts
@@ -265,11 +265,16 @@ export class ReflectionWidgetUI {
                     }
                     // グラフデータ取得・描画（既存）
                     const days = getLastNDays(7);
-                    const filteredPosts: TweetWidgetPost[] = posts.filter(p => {
-                        const d = getDateKey(new Date(p.created));
-                        return days.includes(d) && !p.deleted;
-                    });
-                    const counts = days.map(day => filteredPosts.filter(p => getDateKey(new Date(p.created)) === day).length);
+                    const daySet = new Set(days);
+                    const countMap: Record<string, number> = {};
+                    for (const post of posts) {
+                        if (post.deleted) continue;
+                        const d = getDateKey(new Date(post.created));
+                        if (daySet.has(d)) {
+                            countMap[d] = (countMap[d] || 0) + 1;
+                        }
+                    }
+                    const counts = days.map(d => countMap[d] || 0);
                     if (this.lastChartData && this.lastChartData.length === counts.length && this.lastChartData.every((v, i) => v === counts[i])) {
                         // 何もしない
                     } else if (this.canvasEl) {
@@ -308,8 +313,8 @@ export class ReflectionWidgetUI {
                                     }
                                 }
                             });
-                            this.lastChartData = [...counts];
                         }
+                        this.lastChartData = [...counts];
                     }
                 })(),
                 timeoutPromise


### PR DESCRIPTION
## Summary
- preload Chart.js module during plugin load
- reduce iteration in ReflectionWidget graph data creation
- update chart data cache after redraw

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68440a9d596083208405372a22ba46d5