### PR TITLE
Improve reflection widget caching

### DIFF
--- a/src/modal.ts
+++ b/src/modal.ts
@@ -5,6 +5,7 @@ import { registeredWidgetImplementations } from './widgetRegistry';
 import type { WidgetImplementation, BoardConfiguration, WidgetConfig } from './interfaces';
 import cloneDeep from 'lodash.clonedeep';
 import { preloadChartJS, loadReflectionSummaryShared } from './widgets/reflectionWidget/reflectionWidgetUI';
+import { loadChartCache } from './widgets/reflectionWidget/chartCache';
 import type { ReflectionWidgetPreloadBundle } from './widgets/reflectionWidget/reflectionWidget';
 
 /**
@@ -517,11 +518,12 @@ export class WidgetBoardModal {
                 return [start, end];
             })();
             const weekKey = [weekEnd.getFullYear(), String(weekEnd.getMonth() + 1).padStart(2, '0'), String(weekEnd.getDate()).padStart(2, '0')].join('-');
-            const [todaySummary, weekSummary] = await Promise.all([
+            const [todaySummary, weekSummary, chartData] = await Promise.all([
                 loadReflectionSummaryShared('today', todayKey, this.plugin.app),
-                loadReflectionSummaryShared('week', weekKey, this.plugin.app)
+                loadReflectionSummaryShared('week', weekKey, this.plugin.app),
+                loadChartCache(this.plugin.app)
             ]);
-            reflectionPreloadBundle = { chartModule, todaySummary, weekSummary };
+            reflectionPreloadBundle = { chartModule, todaySummary, weekSummary, chartData };
         }
         // --- Lazy Load & 非同期描画 ---
         const observer = new IntersectionObserver((entries, obs) => {

--- a/src/widgets/reflectionWidget/chartCache.ts
+++ b/src/widgets/reflectionWidget/chartCache.ts
@@ -1,0 +1,50 @@
+import { App } from 'obsidian';
+import type { TweetWidgetPost } from '../tweetWidget/types';
+
+function getDateKey(date: Date): string {
+    return date.toISOString().slice(0, 10);
+}
+
+function getLastNDays(n: number): string[] {
+    const days: string[] = [];
+    const now = new Date();
+    for (let i = n - 1; i >= 0; i--) {
+        const d = new Date(now.getFullYear(), now.getMonth(), now.getDate() - i);
+        days.push(getDateKey(d));
+    }
+    return days;
+}
+
+export async function saveChartCache(app: App, posts: TweetWidgetPost[]): Promise<void> {
+    const days = getLastNDays(7);
+    const daySet = new Set(days);
+    const countMap: Record<string, number> = {};
+    for (const post of posts) {
+        if ((post as any).deleted) continue;
+        const d = getDateKey(new Date(post.created));
+        if (daySet.has(d)) {
+            countMap[d] = (countMap[d] || 0) + 1;
+        }
+    }
+    const counts = days.map(d => countMap[d] || 0);
+    const path = 'data.json';
+    let data: any = {};
+    try {
+        const raw = await app.vault.adapter.read(path);
+        data = JSON.parse(raw);
+    } catch {}
+    data.reflectionChartCache = { postCount: posts.length, days, counts };
+    await app.vault.adapter.write(path, JSON.stringify(data, null, 2));
+}
+
+export async function loadChartCache(app: App): Promise<{postCount:number, days:string[], counts:number[]} | null> {
+    const path = 'data.json';
+    try {
+        const raw = await app.vault.adapter.read(path);
+        const data = JSON.parse(raw);
+        if (data.reflectionChartCache) {
+            return data.reflectionChartCache;
+        }
+    } catch {}
+    return null;
+}

--- a/src/widgets/reflectionWidget/reflectionWidget.ts
+++ b/src/widgets/reflectionWidget/reflectionWidget.ts
@@ -125,6 +125,7 @@ export interface ReflectionWidgetPreloadBundle {
     chartModule: any;
     todaySummary: { summary: string|null, html: string|null };
     weekSummary: { summary: string|null, html: string|null };
+    chartData: { days: string[]; counts: number[]; postCount: number } | null;
 }
 
 // WidgetImplementation型を拡張

--- a/src/widgets/tweetWidget/tweetWidget.ts
+++ b/src/widgets/tweetWidget/tweetWidget.ts
@@ -17,6 +17,7 @@ import { TweetWidgetUI } from './tweetWidgetUI';
 import { TweetRepository } from './TweetRepository';
 import { TweetStore } from './TweetStore';
 import { DEFAULT_TWEET_WIDGET_SETTINGS } from './constants';
+import { saveChartCache } from '../reflectionWidget/chartCache';
 
 export class TweetWidget implements WidgetImplementation {
     // --- Public properties for UI and Plugin ---
@@ -89,6 +90,9 @@ export class TweetWidget implements WidgetImplementation {
             // update path in case settings changed while widget is open
             this.repository.setPath(this.getTweetDbPath());
             await this.repository.save(this.store.settings);
+            try {
+                await saveChartCache(this.app, this.store.settings.posts);
+            } catch {}
             this.saveTimeout = null;
         }, 500);
     }


### PR DESCRIPTION
## Summary
- preload chart data and AI summaries before widget creation
- cache reflection chart counts in `data.json`
- reuse cached HTML to skip markdown rendering
- update chart cache whenever tweet posts are saved

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684436599b708320a7ee610029f1471f