### PR TITLE
Update AI summary cache after save

### DIFF
--- a/src/widgets/reflectionWidget/reflectionWidget.ts
+++ b/src/widgets/reflectionWidget/reflectionWidget.ts
@@ -123,8 +123,8 @@ async function clearOldReflectionSummaries(app: App) {
 // プリロードバンドル型を定義
 export interface ReflectionWidgetPreloadBundle {
     chartModule: any;
-    todaySummary: { summary: string|null, html: string|null };
-    weekSummary: { summary: string|null, html: string|null };
+    todaySummary: { summary: string|null, html: string|null, postCount: number };
+    weekSummary: { summary: string|null, html: string|null, postCount: number };
 }
 
 // WidgetImplementation型を拡張


### PR DESCRIPTION
## Summary
- maintain summary cache in memory when saving reflection summaries
- propagate post counts along with summary and HTML
- expand preload bundle types for post count

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68443ff908508320994f16d0563a0518