### PR TITLE
Improve chart performance with cached tweet counts

### DIFF
--- a/__tests__/widgets/tweetWidget.test.ts
+++ b/__tests__/widgets/tweetWidget.test.ts
@@ -15,7 +15,12 @@ describe('TweetWidget', () => {
     },
     workspace: { getActiveFile: jest.fn(() => ({ path: 'active.md' })) },
   } as any;
-  const dummyPlugin = { settings: { defaultTweetPeriod: 'all', defaultTweetCustomDays: 1 }, manifest: { id: 'test-plugin' } } as any;
+  const dummyPlugin = {
+    settings: { defaultTweetPeriod: 'all', defaultTweetCustomDays: 1 },
+    manifest: { id: 'test-plugin' },
+    updateTweetPostCount: jest.fn(),
+    getTweetPostCounts: jest.fn(() => [])
+  } as any;
 
   it('createメソッドでHTMLElementを返す', () => {
     const widget = new TweetWidget();

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,9 @@ export default class WidgetBoardPlugin extends Plugin {
     private registeredGroupCommandIds: string[] = [];
     llmManager: LLMManager;
     tweetPostCountCache: Record<string, number> = {};
+    tweetChartDirty: boolean = true;
+    tweetChartImageData: string | null = null;
+    tweetChartCountsKey: string | null = null;
 
     /**
      * プラグインの初期化処理
@@ -379,6 +382,7 @@ export default class WidgetBoardPlugin extends Plugin {
         if (this.tweetPostCountCache[key] <= 0) {
             delete this.tweetPostCountCache[key];
         }
+        this.tweetChartDirty = true;
     }
 
     public getTweetPostCounts(days: string[]): number[] {

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,10 @@ import { debugLog } from './utils/logger';
 import { Component, TFile } from 'obsidian';
 import { preloadChartJS } from './widgets/reflectionWidget/reflectionWidgetUI';
 
+function getDateKey(date: Date): string {
+    return date.toISOString().slice(0, 10);
+}
+
 /**
  * Obsidian Widget Board Pluginのメインクラス
  * - ウィジェットボードの管理・設定・コマンド登録などを担当
@@ -31,6 +35,7 @@ export default class WidgetBoardPlugin extends Plugin {
     private isSaving: boolean = false;
     private registeredGroupCommandIds: string[] = [];
     llmManager: LLMManager;
+    tweetPostCountCache: Record<string, number> = {};
 
     /**
      * プラグインの初期化処理
@@ -43,6 +48,7 @@ export default class WidgetBoardPlugin extends Plugin {
         // Preload Chart.js for ReflectionWidget without blocking startup
         setTimeout(() => preloadChartJS().catch(() => {}), 0);
         await this.loadSettings();
+        await this.initTweetPostCountCache();
         this.registerAllBoardCommands();
         this.addRibbonIcon('layout-dashboard', 'ウィジェットボードを開く', () => this.openBoardPicker());
         this.addSettingTab(new WidgetBoardSettingTab(this.app, this));
@@ -351,6 +357,32 @@ export default class WidgetBoardPlugin extends Plugin {
         this.widgetBoardModals.forEach(modal => {
             if (modal.isOpen) modal.close();
         });
+    }
+
+    private async initTweetPostCountCache() {
+        const dbPath = this.settings.baseFolder
+            ? `${this.settings.baseFolder.replace(/\/$/, '')}/tweets.json`
+            : 'tweets.json';
+        const repo = new TweetRepository(this.app, dbPath);
+        const tweetSettings = await repo.load();
+        this.tweetPostCountCache = {};
+        for (const p of tweetSettings.posts || []) {
+            if (p.deleted) continue;
+            const key = getDateKey(new Date(p.created));
+            this.tweetPostCountCache[key] = (this.tweetPostCountCache[key] || 0) + 1;
+        }
+    }
+
+    public updateTweetPostCount(created: number, delta: number) {
+        const key = getDateKey(new Date(created));
+        this.tweetPostCountCache[key] = (this.tweetPostCountCache[key] || 0) + delta;
+        if (this.tweetPostCountCache[key] <= 0) {
+            delete this.tweetPostCountCache[key];
+        }
+    }
+
+    public getTweetPostCounts(days: string[]): number[] {
+        return days.map(d => this.tweetPostCountCache[d] || 0);
     }
 
     /**

--- a/src/widgets/reflectionWidget/reflectionWidgetUI.ts
+++ b/src/widgets/reflectionWidget/reflectionWidgetUI.ts
@@ -369,18 +369,9 @@ export class ReflectionWidgetUI {
                             this.app
                         );
                     }
-                    // グラフデータ取得・描画（既存）
+                    // グラフデータ取得・描画
                     const days = getLastNDays(7);
-                    const daySet = new Set(days);
-                    const countMap: Record<string, number> = {};
-                    for (const post of posts) {
-                        if (post.deleted) continue;
-                        const d = getDateKey(new Date(post.created));
-                        if (daySet.has(d)) {
-                            countMap[d] = (countMap[d] || 0) + 1;
-                        }
-                    }
-                    const counts = days.map(d => countMap[d] || 0);
+                    const counts = this.plugin.getTweetPostCounts(days);
                     if (this.lastChartData && this.lastChartData.length === counts.length && this.lastChartData.every((v, i) => v === counts[i])) {
                         // 何もしない
                     } else if (this.canvasEl) {


### PR DESCRIPTION
## Summary
- build cache of tweet counts during plugin initialization
- update cache on new posts, deletions, and thread operations
- use cached counts when rendering ReflectionWidget chart
- adjust tests for new plugin methods

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684463c7e7948320959df98da5e409d9