### PR TITLE
Implement YouTube title caching

### DIFF
--- a/__tests__/utils/fetchYouTubeTitle.test.ts
+++ b/__tests__/utils/fetchYouTubeTitle.test.ts
@@ -1,0 +1,24 @@
+jest.mock('../../src/utils', () => ({
+  safeFetch: jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ title: 't1' }) }))
+}));
+
+import { safeFetch } from '../../src/utils';
+import { fetchYouTubeTitle, __clearYouTubeTitleCache, __setYouTubeTitleTTL } from '../../src/widgets/tweetWidget/tweetWidgetUtils.ts';
+
+beforeEach(() => {
+  __clearYouTubeTitleCache();
+  __setYouTubeTitleTTL(1000 * 60 * 60 * 24);
+  (safeFetch as jest.Mock).mockClear();
+  localStorage.clear();
+});
+
+test('caches title result', async () => {
+  const title1 = await fetchYouTubeTitle('https://youtu.be/abc');
+  expect(title1).toBe('t1');
+  expect((safeFetch as jest.Mock).mock.calls.length).toBe(1);
+
+  const title2 = await fetchYouTubeTitle('https://youtu.be/abc');
+  expect(title2).toBe('t1');
+  expect((safeFetch as jest.Mock).mock.calls.length).toBe(1);
+});
+

--- a/__tests__/utils/fetchYouTubeTitle.test.ts
+++ b/__tests__/utils/fetchYouTubeTitle.test.ts
@@ -22,3 +22,12 @@ test('caches title result', async () => {
   expect((safeFetch as jest.Mock).mock.calls.length).toBe(1);
 });
 
+test('deduplicates concurrent fetches', async () => {
+  const p1 = fetchYouTubeTitle('https://youtu.be/xyz');
+  const p2 = fetchYouTubeTitle('https://youtu.be/xyz');
+  const [t1, t2] = await Promise.all([p1, p2]);
+  expect(t1).toBe('t1');
+  expect(t2).toBe('t1');
+  expect((safeFetch as jest.Mock).mock.calls.length).toBe(1);
+});
+

--- a/src/widgets/tweetWidget/tweetWidgetUtils.ts
+++ b/src/widgets/tweetWidget/tweetWidgetUtils.ts
@@ -90,7 +90,19 @@ export function extractYouTubeUrl(text: string): string | null {
 let YOUTUBE_TITLE_TTL = 1000 * 60 * 60 * 24; // 24h
 type CachedTitle = { title: string | null; time: number };
 const YT_CACHE_KEY = 'tweetWidget.youtubeTitleCache';
-let youtubeTitleCache = new Map<string, CachedTitle>();
+declare global {
+    interface Window { tweetWidgetYouTubeTitleCache?: Map<string, CachedTitle>; }
+}
+let youtubeTitleCache: Map<string, CachedTitle>;
+const shouldLoadFromStorage = typeof window !== 'undefined' && !(window as any).tweetWidgetYouTubeTitleCache;
+if (typeof window !== 'undefined') {
+    youtubeTitleCache = (window as any).tweetWidgetYouTubeTitleCache || new Map();
+    if (!(window as any).tweetWidgetYouTubeTitleCache) {
+        (window as any).tweetWidgetYouTubeTitleCache = youtubeTitleCache;
+    }
+} else {
+    youtubeTitleCache = new Map();
+}
 const pendingRequests = new Map<string, Promise<string | null>>();
 
 export function __loadYouTubeTitleCache() {
@@ -110,7 +122,9 @@ function saveYouTubeTitleCache() {
     } catch {}
 }
 
-__loadYouTubeTitleCache();
+if (shouldLoadFromStorage) {
+    __loadYouTubeTitleCache();
+}
 
 function refreshYouTubeTitle(url: string) {
     if (pendingRequests.has(url)) {


### PR DESCRIPTION
## Summary
- cache YouTube titles for Tweet widget and refresh in the background on TTL expiry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684469f90b308320b145057c0f1983c1