### PR TITLE
Use Buffer for obfuscation

### DIFF
--- a/src/utils/safeFetch.ts
+++ b/src/utils/safeFetch.ts
@@ -87,12 +87,12 @@ function createReadableStreamFromString(input: string) {
 
 // APIキーなどの簡易難読化（Base64）
 export function obfuscate(str: string): string {
-    return btoa(unescape(encodeURIComponent(str)));
+  return Buffer.from(str, 'utf8').toString('base64');
 }
 export function deobfuscate(str: string): string {
-    try {
-        return decodeURIComponent(escape(atob(str)));
-    } catch {
-        return '';
-    }
-} 
+  try {
+    return Buffer.from(str, 'base64').toString('utf8');
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
## Summary
- replace legacy `escape/unescape` obfuscation with `Buffer` utilities

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684502791d588320b175b8b946bb8bf5