### PR TITLE
Centralize date utilities

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,10 +19,7 @@ import { debugLog } from './utils/logger';
 import { filterConsoleWarn } from './utils/consoleWarnFilter';
 import { Component, TFile } from 'obsidian';
 import { preloadChartJS } from './widgets/reflectionWidget/reflectionWidgetUI';
-
-function getDateKey(date: Date): string {
-    return date.toISOString().slice(0, 10);
-}
+import { getDateKey, getWeekRange } from './utils';
 
 /**
  * Obsidian Widget Board Pluginのメインクラス
@@ -450,11 +447,9 @@ export default class WidgetBoardPlugin extends Plugin {
                 } catch {}
                 return null;
             }
-            const todayKey = (new Date()).toISOString().slice(0, 10);
-            const now = new Date();
-            const day = now.getDay();
-            const weekEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate() + (6 - day));
-            const weekKey = weekEnd.toISOString().slice(0, 10);
+            const todayKey = getDateKey(new Date());
+            const [, weekEnd] = getWeekRange();
+            const weekKey = weekEnd;
             const todaySummary = await loadReflectionSummary('today', todayKey, this.app);
             const weekSummary = await loadReflectionSummary('week', weekKey, this.app);
 

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -5,6 +5,7 @@ import { registeredWidgetImplementations } from './widgetRegistry';
 import type { WidgetImplementation, BoardConfiguration, WidgetConfig } from './interfaces';
 import cloneDeep from 'lodash.clonedeep';
 import { preloadChartJS, loadReflectionSummaryShared } from './widgets/reflectionWidget/reflectionWidgetUI';
+import { getDateKeyLocal, getWeekRange } from './utils';
 import type { ReflectionWidgetPreloadBundle } from './widgets/reflectionWidget/reflectionWidget';
 
 /**
@@ -505,18 +506,8 @@ export class WidgetBoardModal {
         let reflectionPreloadBundle: ReflectionWidgetPreloadBundle | undefined = undefined;
         if (widgetsToLoad.some(w => w.type === 'reflection-widget')) {
             const chartModule = await preloadChartJS();
-            const todayKey = (() => {
-                const now = new Date();
-                return [now.getFullYear(), String(now.getMonth() + 1).padStart(2, '0'), String(now.getDate()).padStart(2, '0')].join('-');
-            })();
-            const [weekStart, weekEnd] = (() => {
-                const now = new Date();
-                const day = now.getDay();
-                const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - day);
-                const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + (6 - day));
-                return [start, end];
-            })();
-            const weekKey = [weekEnd.getFullYear(), String(weekEnd.getMonth() + 1).padStart(2, '0'), String(weekEnd.getDate()).padStart(2, '0')].join('-');
+            const todayKey = getDateKeyLocal(new Date());
+            const [, weekKey] = getWeekRange();
             const [todaySummary, weekSummary] = await Promise.all([
                 loadReflectionSummaryShared('today', todayKey, this.plugin.app),
                 loadReflectionSummaryShared('week', weekKey, this.plugin.app)

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,23 @@
+export function pad2(n: number): string {
+    return n.toString().padStart(2, '0');
+}
+
+export function getDateKey(date: Date): string {
+    return date.toISOString().slice(0, 10);
+}
+
+export function getDateKeyLocal(date: Date): string {
+    return [
+        date.getFullYear(),
+        pad2(date.getMonth() + 1),
+        pad2(date.getDate())
+    ].join('-');
+}
+
+export function getWeekRange(): [string, string] {
+    const now = new Date();
+    const day = now.getDay();
+    const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - day);
+    const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + (6 - day));
+    return [getDateKey(start), getDateKey(end)];
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from './widgetSize';
 export * from './logger';
 export * from './mermaidRenderWorkerClient';
 export * from './consoleWarnFilter';
+export * from './date';

--- a/src/widgets/calendar/index.ts
+++ b/src/widgets/calendar/index.ts
@@ -4,7 +4,7 @@ import { DEFAULT_CALENDAR_SETTINGS } from '../../settingsDefaults';
 import type { WidgetConfig, WidgetImplementation } from '../../interfaces';
 import type WidgetBoardPlugin from '../../main';
 import { debugLog } from '../../utils/logger';
-import { applyWidgetSize, createWidgetContainer } from '../../utils';
+import { applyWidgetSize, createWidgetContainer, pad2 } from '../../utils';
 import moment from 'moment';
 
 // --- カレンダーウィジェット設定インターフェース ---
@@ -124,7 +124,7 @@ export class CalendarWidget implements WidgetImplementation {
                 const y = cellDate.getFullYear();
                 const m = cellDate.getMonth() + 1;
                 const d = cellDate.getDate();
-                const dateStr = `${y}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+                const dateStr = `${y}-${pad2(m)}-${pad2(d)}`;
                 td.setAttr('data-date', dateStr);
                 if (cellDate.getMonth() !== month) {
                     td.addClass('calendar-other-month');
@@ -200,8 +200,8 @@ export class CalendarWidget implements WidgetImplementation {
         const format = globalFormat;
         debugLog(this.plugin, 'calendar format:', format, 'dateStr:', dateStr);
         const [y, m, d] = dateStr.split('-');
-        const MM = m.padStart(2, '0');
-        const DD = d.padStart(2, '0');
+        const MM = pad2(parseInt(m, 10));
+        const DD = pad2(parseInt(d, 10));
         let dailyNoteName = format.toUpperCase()
             .replace(/YYYY/g, y)
             .replace(/MM/g, MM)

--- a/src/widgets/pomodoro/index.ts
+++ b/src/widgets/pomodoro/index.ts
@@ -4,7 +4,7 @@ import type { WidgetConfig, WidgetImplementation } from '../../interfaces';
 import type WidgetBoardPlugin from '../../main'; // main.ts の WidgetBoardPlugin クラスをインポート
 import { PomodoroMemoWidget, PomodoroMemoSettings } from './pomodoroMemoWidget';
 import { debugLog } from '../../utils/logger';
-import { applyWidgetSize, createWidgetContainer } from '../../utils';
+import { applyWidgetSize, createWidgetContainer, pad2, getDateKeyLocal } from '../../utils';
 
 // --- 通知音の種類の型定義 ---
 export type PomodoroSoundType = 'off' | 'default_beep' | 'bell' | 'chime';
@@ -376,7 +376,7 @@ export class PomodoroWidget implements WidgetImplementation {
     private formatTime(totalSeconds: number): string {
         const m = Math.floor(totalSeconds / 60);
         const s = totalSeconds % 60;
-        return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+        return `${pad2(m)}:${pad2(s)}`;
     }
 
     /**
@@ -575,10 +575,9 @@ export class PomodoroWidget implements WidgetImplementation {
                 startDate = new Date();
                 endDate = new Date();
             }
-            const pad = (n: number) => n.toString().padStart(2, '0');
-            const dateStr = `${startDate.getFullYear()}-${pad(startDate.getMonth() + 1)}-${pad(startDate.getDate())}`;
-            const startStr = `${pad(startDate.getHours())}:${pad(startDate.getMinutes())}`;
-            const endStr = `${pad(endDate.getHours())}:${pad(endDate.getMinutes())}`;
+            const dateStr = getDateKeyLocal(startDate);
+            const startStr = `${pad2(startDate.getHours())}:${pad2(startDate.getMinutes())}`;
+            const endStr = `${pad2(endDate.getHours())}:${pad2(endDate.getMinutes())}`;
             this.sessionLogs.push({
                 date: dateStr,
                 start: startStr,
@@ -598,10 +597,9 @@ export class PomodoroWidget implements WidgetImplementation {
                 startDate = new Date();
                 endDate = new Date();
             }
-            const pad = (n: number) => n.toString().padStart(2, '0');
-            const dateStr = `${startDate.getFullYear()}-${pad(startDate.getMonth() + 1)}-${pad(startDate.getDate())}`;
-            const startStr = `${pad(startDate.getHours())}:${pad(startDate.getMinutes())}`;
-            const endStr = `${pad(endDate.getHours())}:${pad(endDate.getMinutes())}`;
+            const dateStr = getDateKeyLocal(startDate);
+            const startStr = `${pad2(startDate.getHours())}:${pad2(startDate.getMinutes())}`;
+            const endStr = `${pad2(endDate.getHours())}:${pad2(endDate.getMinutes())}`;
             this.sessionLogs.push({
                 date: dateStr,
                 start: startStr,
@@ -621,10 +619,9 @@ export class PomodoroWidget implements WidgetImplementation {
                 startDate = new Date();
                 endDate = new Date();
             }
-            const pad = (n: number) => n.toString().padStart(2, '0');
-            const dateStr = `${startDate.getFullYear()}-${pad(startDate.getMonth() + 1)}-${pad(startDate.getDate())}`;
-            const startStr = `${pad(startDate.getHours())}:${pad(startDate.getMinutes())}`;
-            const endStr = `${pad(endDate.getHours())}:${pad(endDate.getMinutes())}`;
+            const dateStr = getDateKeyLocal(startDate);
+            const startStr = `${pad2(startDate.getHours())}:${pad2(startDate.getMinutes())}`;
+            const endStr = `${pad2(endDate.getHours())}:${pad2(endDate.getMinutes())}`;
             this.sessionLogs.push({
                 date: dateStr,
                 start: startStr,
@@ -660,9 +657,8 @@ export class PomodoroWidget implements WidgetImplementation {
         // セッション未開始でスキップする場合の対応
         if (!this.currentSessionStartTime) {
             const now = new Date();
-            const pad = (n: number) => n.toString().padStart(2, '0');
-            const dateStr = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
-            const timeStr = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
+            const dateStr = getDateKeyLocal(now);
+            const timeStr = `${pad2(now.getHours())}:${pad2(now.getMinutes())}`;
             // 0秒作業ログを記録
             this.sessionLogs.push({
                 date: dateStr,
@@ -686,10 +682,9 @@ export class PomodoroWidget implements WidgetImplementation {
         if (this.currentSessionStartTime) {
             const startDate = this.currentSessionStartTime;
             const endDate = new Date();
-            const pad = (n: number) => n.toString().padStart(2, '0');
-            const dateStr = `${startDate.getFullYear()}-${pad(startDate.getMonth() + 1)}-${pad(startDate.getDate())}`;
-            const startStr = `${pad(startDate.getHours())}:${pad(startDate.getMinutes())}`;
-            const endStr = `${pad(endDate.getHours())}:${pad(endDate.getMinutes())}`;
+            const dateStr = getDateKeyLocal(startDate);
+            const startStr = `${pad2(startDate.getHours())}:${pad2(startDate.getMinutes())}`;
+            const endStr = `${pad2(endDate.getHours())}:${pad2(endDate.getMinutes())}`;
             this.sessionLogs.push({
                 date: dateStr,
                 start: startStr,

--- a/src/widgets/reflectionWidget/reflectionWidget.ts
+++ b/src/widgets/reflectionWidget/reflectionWidget.ts
@@ -6,7 +6,7 @@ import { DEFAULT_TWEET_WIDGET_SETTINGS } from '../tweetWidget/constants';
 import { LLMManager } from '../../llm/llmManager';
 import type { ReflectionWidgetSettings } from './reflectionWidgetTypes';
 import { geminiSummaryPromptToday, geminiSummaryPromptWeek } from '../../llm/gemini/summaryPrompts';
-import { deobfuscate } from '../../utils';
+import { deobfuscate, getDateKey, getDateKeyLocal } from '../../utils';
 import { debugLog } from '../../utils/logger';
 import { ReflectionWidgetUI } from './reflectionWidgetUI';
 
@@ -22,18 +22,6 @@ function getTweetDbPath(plugin: any): string {
     return 'tweets.json';
 }
 
-function getDateKey(date: Date): string {
-    return date.toISOString().slice(0, 10); // YYYY-MM-DD
-}
-
-// ローカルタイム基準でYYYY-MM-DDを返す
-function getDateKeyLocal(date: Date): string {
-    return [
-        date.getFullYear(),
-        String(date.getMonth() + 1).padStart(2, '0'),
-        String(date.getDate()).padStart(2, '0')
-    ].join('-');
-}
 
 function getLastNDays(n: number): string[] {
     const days: string[] = [];
@@ -45,13 +33,6 @@ function getLastNDays(n: number): string[] {
     return days;
 }
 
-function getWeekRange(): [string, string] {
-    const now = new Date();
-    const day = now.getDay(); // 0:日〜6:土
-    const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - day);
-    const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + (6 - day));
-    return [getDateKey(start), getDateKey(end)];
-}
 
 async function generateSummary(posts: TweetWidgetPost[], prompt: string, plugin: any): Promise<string> {
     if (!plugin.llmManager) return 'LLM未初期化';

--- a/src/widgets/reflectionWidget/reflectionWidgetUI.ts
+++ b/src/widgets/reflectionWidget/reflectionWidgetUI.ts
@@ -5,7 +5,7 @@ import type { ReflectionWidgetSettings } from './reflectionWidgetTypes';
 import { TweetRepository } from '../tweetWidget';
 import type { TweetWidgetPost, TweetWidgetSettings } from '../tweetWidget/types';
 import { geminiSummaryPromptToday, geminiSummaryPromptWeek } from  '../../llm/gemini/summaryPrompts';
-import { deobfuscate } from '../../utils';
+import { deobfuscate, getDateKey, getDateKeyLocal, getWeekRange } from '../../utils';
 import { renderMarkdownBatchWithCache } from '../../utils/renderMarkdownBatch';
 import type { ReflectionWidgetPreloadBundle } from './reflectionWidget';
 import { renderMermaidInWorker } from '../../utils';
@@ -33,16 +33,6 @@ export function preloadChartJS(): Promise<any> {
     return chartModulePromise;
 }
 
-function getDateKey(date: Date): string {
-    return date.toISOString().slice(0, 10);
-}
-function getDateKeyLocal(date: Date): string {
-    return [
-        date.getFullYear(),
-        String(date.getMonth() + 1).padStart(2, '0'),
-        String(date.getDate()).padStart(2, '0')
-    ].join('-');
-}
 function getLastNDays(n: number): string[] {
     const days: string[] = [];
     const now = new Date();
@@ -51,13 +41,6 @@ function getLastNDays(n: number): string[] {
         days.push(getDateKey(d));
     }
     return days;
-}
-function getWeekRange(): [string, string] {
-    const now = new Date();
-    const day = now.getDay();
-    const start = new Date(now.getFullYear(), now.getMonth(), now.getDate() - day);
-    const end = new Date(now.getFullYear(), now.getMonth(), now.getDate() + (6 - day));
-    return [getDateKey(start), getDateKey(end)];
 }
 async function generateSummary(posts: TweetWidgetPost[], prompt: string, plugin: any): Promise<string> {
     if (!plugin.llmManager) return 'LLM未初期化';

--- a/src/widgets/timer-stopwatch/index.ts
+++ b/src/widgets/timer-stopwatch/index.ts
@@ -1,7 +1,7 @@
 import { App, Notice, setIcon } from 'obsidian';
 import type { WidgetConfig, WidgetImplementation } from '../../interfaces';
 import type WidgetBoardPlugin from '../../main';
-import { createWidgetContainer } from '../../utils';
+import { createWidgetContainer, pad2 } from '../../utils';
 
 // --- 通知音の種類の型定義 ---
 export type TimerSoundType = 'off' | 'default_beep' | 'bell' | 'chime'; // chime を追加する場合
@@ -436,7 +436,7 @@ export class TimerStopwatchWidget implements WidgetImplementation {
         const t = Math.max(0, Math.round(totalSeconds));
         const m = Math.floor(t / 60);
         const s = t % 60;
-        return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+        return `${pad2(m)}:${pad2(s)}`;
     }
 
     // --- 通知音再生メソッド ---

--- a/src/widgets/tweetWidget/aiReply.ts
+++ b/src/widgets/tweetWidget/aiReply.ts
@@ -1,6 +1,6 @@
 import { geminiPrompt } from '../../llm/gemini/tweetReplyPrompt';
 import { GeminiProvider } from '../../llm/gemini/geminiApi';
-import { deobfuscate } from '../../utils';
+import { deobfuscate, pad2 } from '../../utils';
 import type { TweetWidgetPost, AiGovernanceData } from './types'; // AiGovernanceData をインポート
 import type { PluginGlobalSettings } from '../../interfaces';
 
@@ -151,7 +151,7 @@ export async function generateAiReply({
         // スレッドの最後の投稿の投稿日時を取得
         const lastPost = thread[thread.length - 1];
         const date = new Date(lastPost.created);
-        const dateStr = `${date.getFullYear()}年${date.getMonth()+1}月${date.getDate()}日 ${date.getHours()}時${date.getMinutes().toString().padStart(2, '0')}分`;
+        const dateStr = `${date.getFullYear()}年${date.getMonth()+1}月${date.getDate()}日 ${date.getHours()}時${pad2(date.getMinutes())}分`;
         // 時間帯ラベルを判定
         function getTimeZoneLabel(date: Date): string {
             const hour = date.getHours();

--- a/src/widgets/tweetWidget/tweetWidget.ts
+++ b/src/widgets/tweetWidget/tweetWidget.ts
@@ -2,7 +2,7 @@ import { App, Notice, TFile } from 'obsidian';
 import type { WidgetConfig, WidgetImplementation } from '../../interfaces';
 import type WidgetBoardPlugin from '../../main';
 import { GeminiProvider } from '../../llm/gemini/geminiApi';
-import { deobfuscate } from '../../utils';
+import { deobfuscate, pad2, getDateKeyLocal } from '../../utils';
 import { geminiPrompt } from '../../llm/gemini/tweetReplyPrompt';
 import { debugLog } from '../../utils/logger';
 import { applyWidgetSize, createWidgetContainer } from '../../utils';
@@ -417,7 +417,7 @@ export class TweetWidget implements WidgetImplementation {
             // スレッドの最後の投稿の投稿日時を取得
             const lastPost = thread[thread.length - 1];
             const date = new Date(lastPost.created);
-            const dateStr = `${date.getFullYear()}年${date.getMonth()+1}月${date.getDate()}日 ${date.getHours()}時${date.getMinutes().toString().padStart(2, '0')}分`;
+            const dateStr = `${date.getFullYear()}年${date.getMonth()+1}月${date.getDate()}日 ${date.getHours()}時${pad2(date.getMinutes())}分`;
             // 時間帯ラベルを判定
             function getTimeZoneLabel(date: Date): string {
                 const hour = date.getHours();
@@ -519,16 +519,9 @@ export class TweetWidget implements WidgetImplementation {
             if (this.currentPeriod === 'today') {
                 // ローカルタイムで今日の日付
                 const today = new Date();
-                const yyyy = today.getFullYear();
-                const mm = String(today.getMonth() + 1).padStart(2, '0');
-                const dd = String(today.getDate()).padStart(2, '0');
-                const todayStr = `${yyyy}-${mm}-${dd}`;
+                const todayStr = getDateKeyLocal(today);
                 posts = posts.filter(p => {
-                    const d = new Date(p.created);
-                    const yyyy2 = d.getFullYear();
-                    const mm2 = String(d.getMonth() + 1).padStart(2, '0');
-                    const dd2 = String(d.getDate()).padStart(2, '0');
-                    const dateStr = `${yyyy2}-${mm2}-${dd2}`;
+                    const dateStr = getDateKeyLocal(new Date(p.created));
                     return dateStr === todayStr;
                 });
             } else if (this.currentPeriod === 'custom') {

--- a/src/widgets/tweetWidget/tweetWidgetDataViewer.ts
+++ b/src/widgets/tweetWidget/tweetWidgetDataViewer.ts
@@ -1,5 +1,6 @@
 import type { TweetWidgetPost } from './types';
 import { Notice } from 'obsidian';
+import { pad2 } from '../../utils';
 
 const ALL_COLUMNS = [
     { key: 'id', label: 'ID' },
@@ -199,7 +200,7 @@ export class TweetWidgetDataViewer {
 
     private formatDate(ts: number): string {
         const d = new Date(ts);
-        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+        return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())} ${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
     }
 
     private copyCsvToClipboard() {


### PR DESCRIPTION
## Summary
- add new `src/utils/date.ts` with common date helpers
- re-export helpers from `src/utils/index.ts`
- use new helpers across widgets and plugin code
- remove duplicated local implementations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68452146d0a4832098051ac8a78c502b