### PR TITLE
Use OffscreenCanvas worker for chart rendering

### DIFF
--- a/src/utils/chartWorker.ts
+++ b/src/utils/chartWorker.ts
@@ -1,0 +1,43 @@
+let Chart: any;
+
+self.onmessage = async (e) => {
+  const { id, labels, data, width, height } = e.data;
+  if (!Chart) {
+    const mod = await import('chart.js/auto');
+    Chart = mod.default;
+  }
+  const Offscreen = (self as any).OffscreenCanvas;
+  const canvas = new Offscreen(width, height);
+  const ctx = canvas.getContext('2d');
+  new Chart(ctx as any, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [{
+        label: '投稿数',
+        data,
+        borderColor: '#4a90e2',
+        backgroundColor: 'rgba(74,144,226,0.15)',
+        fill: true,
+        tension: 0.3,
+        pointRadius: 3,
+      }]
+    },
+    options: {
+      responsive: false,
+      animation: false,
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { grid: { display: false }, ticks: { maxTicksLimit: 5 } },
+        y: { beginAtZero: true, grid: { color: '#eee' } }
+      }
+    }
+  });
+  await new Promise(r => setTimeout(r, 0));
+  const blob = await canvas.convertToBlob();
+  const reader = new FileReader();
+  reader.onload = () => {
+    self.postMessage({ id, dataUrl: reader.result });
+  };
+  reader.readAsDataURL(blob);
+};

--- a/src/utils/chartWorkerClient.ts
+++ b/src/utils/chartWorkerClient.ts
@@ -1,0 +1,32 @@
+let chartWorker: Worker | null = null;
+
+function getChartWorker(): Worker {
+  if (!chartWorker) {
+    // @ts-ignore
+    chartWorker = new Worker('src/utils/chartWorker.ts', { type: 'module' });
+  }
+  return chartWorker;
+}
+
+export function renderChartInWorker(labels: string[], data: number[], width: number, height: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    if (!('OffscreenCanvas' in globalThis)) {
+      reject(new Error('OffscreenCanvas not supported'));
+      return;
+    }
+    const worker = getChartWorker();
+    const id = Math.random().toString(36).slice(2);
+    const handle = (e: MessageEvent) => {
+      if (e.data && e.data.id === id) {
+        worker.removeEventListener('message', handle);
+        if (e.data.dataUrl) {
+          resolve(e.data.dataUrl as string);
+        } else {
+          reject(new Error('Chart worker error'));
+        }
+      }
+    };
+    worker.addEventListener('message', handle);
+    worker.postMessage({ id, labels, data, width, height });
+  });
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,5 +2,6 @@ export * from './safeFetch';
 export * from './widgetSize';
 export * from './logger';
 export * from './mermaidRenderWorkerClient';
+export * from './chartWorkerClient';
 export * from './consoleWarnFilter';
 export * from './date';


### PR DESCRIPTION
## Summary
- render charts with `renderChartInWorker`
- add chart worker and client utilities

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845248d69b08320a416c6f432c10588