### PR TITLE
Refactor modal open animation

### DIFF
--- a/src/modal.ts
+++ b/src/modal.ts
@@ -152,9 +152,6 @@ export class WidgetBoardModal {
         if (this.isOpen) return;
         document.body.appendChild(this.modalEl);
         this.onOpen();
-        // アニメーションクラスの付与だけをrAFで行う
-        this.modalEl.classList.remove('is-open');
-        void this.modalEl.offsetWidth;
         requestAnimationFrame(() => {
             this.modalEl.classList.add('is-open');
         });
@@ -466,9 +463,6 @@ export class WidgetBoardModal {
             }
         });
 
-        requestAnimationFrame(() => {
-            modalEl.classList.add('is-open');
-        });
     }
 
     /**

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,11 @@
+/* Generic modal visibility */
+.modal {
+    opacity: 0;
+}
+.modal.is-open {
+    opacity: 1;
+}
+
 /* Panel styles */
 .widget-board-panel-custom {
     padding: 0 !important;


### PR DESCRIPTION
## Summary
- control modal visibility via CSS classes
- simplify `WidgetBoardModal.open()` animation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684586f7491483209512d968e06ae4dc