### PR TITLE
Fix outer board CSS removal on closing other boards

### DIFF
--- a/src/modal.ts
+++ b/src/modal.ts
@@ -827,8 +827,12 @@ export class WidgetBoardModal {
             this.removeDragDropListeners(widgetContainerEl);
         }
         modalEl.classList.remove('is-open');
-        // 右・左スプリット外モード時はbodyの専用クラスを削除
-        document.body.classList.remove('wb-modal-right-outer-open', 'wb-modal-left-outer-open');
+        // 右・左スプリット外モード時のみbodyの専用クラスを削除
+        if (this.currentMode === WidgetBoardModal.MODES.RIGHT_OUTER) {
+            document.body.classList.remove('wb-modal-right-outer-open');
+        } else if (this.currentMode === WidgetBoardModal.MODES.LEFT_OUTER) {
+            document.body.classList.remove('wb-modal-left-outer-open');
+        }
         setTimeout(() => {
             this.onClose();
             const selector = `.widget-board-panel-custom[data-board-id='${this.currentBoardId}']`;


### PR DESCRIPTION
## Summary
- remove outer-board CSS only when closing an outer mode board

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68462bc2f3748320a1fb488b17d4e17d