### PR TITLE
Fix: つぶやきのスレッドを表示する際，タイムラインのスクロール位置が適用される問題を修正

### DIFF
--- a/src/widgets/tweetWidget/tweetWidgetUI.ts
+++ b/src/widgets/tweetWidget/tweetWidgetUI.ts
@@ -686,6 +686,10 @@ export class TweetWidgetUI {
     }
 
     private renderDetailView(container: HTMLElement, postId: string): void {
+        // スクロール位置をトップに戻す
+        const scrollContainer = this.container.closest('.widget-board-panel-custom');
+        if (scrollContainer) scrollContainer.scrollTop = 0;
+
         const target = this.postsById.get(postId);
         if (!target) return;
 


### PR DESCRIPTION
タイムラインからつぶやきのスレッドを表示する際にタイムラインのスクロール位置がそのままつぶやきのスレッドでも適用され，つぶやきのスレッドを表示した際にスレッドの途中が表示される問題を確認しました．

簡易的にDetailViewの描画時にスクロール位置をトップに戻す処理を挟みましたが，よりよい修正案がございましたらそちらを使用して頂いて構いません．
