### PR TITLE
Add scroll reset for tweet detail views

### DIFF
--- a/__tests__/widgets/tweetWidget.test.ts
+++ b/__tests__/widgets/tweetWidget.test.ts
@@ -120,6 +120,17 @@ describe('TweetWidget', () => {
     expect(widget.detailPostId).toBe(post.id);
   });
 
+  it('navigateToDetailでresetScrollが呼ばれる', async () => {
+    const widget = new TweetWidget();
+    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await new Promise(res => setTimeout(res, 0));
+    await widget.submitPost('scroll test');
+    const post = widget.currentSettings.posts[0];
+    const spy = jest.spyOn(widget['ui'], 'resetScroll');
+    widget.navigateToDetail(post.id);
+    expect(spy).toHaveBeenCalled();
+  });
+
   it('ファイル添付でattachedFilesが更新される', async () => {
     dummyApp.vault.createBinary = jest.fn();
     const widget = new TweetWidget();

--- a/src/widgets/tweetWidget/tweetWidget.ts
+++ b/src/widgets/tweetWidget/tweetWidget.ts
@@ -109,6 +109,7 @@ export class TweetWidget implements WidgetImplementation {
     public navigateToDetail(postId: string | null) {
         this.detailPostId = postId;
         this.currentTab = 'home';
+        this.ui.resetScroll();
         this.ui.render();
     }
     

--- a/src/widgets/tweetWidget/tweetWidgetUI.ts
+++ b/src/widgets/tweetWidget/tweetWidgetUI.ts
@@ -63,6 +63,10 @@ export class TweetWidgetUI {
         this.postsById = widget.postsById;
     }
 
+    public resetScroll(): void {
+        this.container.scrollTop = 0;
+    }
+
     public scheduleRender(): void {
         if (this.needsRender) return;
         this.needsRender = true;


### PR DESCRIPTION
## Summary
- add `resetScroll` method to `TweetWidgetUI`
- call `resetScroll` before rendering in `navigateToDetail`
- test `navigateToDetail` triggers `resetScroll`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ab979bc108320946edcad3865505d