### PR TITLE
Fix tweet detail scroll reset

### DIFF
--- a/__tests__/widgets/tweetWidget.test.ts
+++ b/__tests__/widgets/tweetWidget.test.ts
@@ -131,6 +131,23 @@ describe('TweetWidget', () => {
     expect(spy).toHaveBeenCalled();
   });
 
+  it('navigateToDetailでボードパネルのscrollTopがリセットされる', async () => {
+    const widget = new TweetWidget();
+    const panel = document.createElement('div');
+    panel.className = 'widget-board-panel-custom';
+    document.body.appendChild(panel);
+    const el = widget.create(dummyConfig, dummyApp, dummyPlugin);
+    panel.appendChild(el);
+    await new Promise(res => setTimeout(res, 0));
+    await widget.submitPost('scroll test');
+    const post = widget.currentSettings.posts[0];
+    (widget as any)['ui'].container.scrollTop = 50;
+    panel.scrollTop = 50;
+    widget.navigateToDetail(post.id);
+    expect((widget as any)['ui'].container.scrollTop).toBe(0);
+    expect(panel.scrollTop).toBe(0);
+  });
+
   it('ファイル添付でattachedFilesが更新される', async () => {
     dummyApp.vault.createBinary = jest.fn();
     const widget = new TweetWidget();

--- a/src/widgets/tweetWidget/tweetWidgetUI.ts
+++ b/src/widgets/tweetWidget/tweetWidgetUI.ts
@@ -65,6 +65,8 @@ export class TweetWidgetUI {
 
     public resetScroll(): void {
         this.container.scrollTop = 0;
+        const panel = this.container.closest('.widget-board-panel-custom');
+        if (panel instanceof HTMLElement) panel.scrollTop = 0;
     }
 
     public scheduleRender(): void {


### PR DESCRIPTION
## Summary
- reset board panel scroll when opening tweet details
- test that scrollTop of panel resets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68515e19b3188320b3dd6eb1ed9e53fa