### PR TITLE
Fix detail view focus after deleting a tweet

### DIFF
--- a/__tests__/widgets/tweetWidget.test.ts
+++ b/__tests__/widgets/tweetWidget.test.ts
@@ -182,6 +182,21 @@ describe('TweetWidget', () => {
     expect(widget.detailPostId).toBe(parentId);
   });
 
+  it('スレッド削除中に表示していた投稿が含まれる場合親にフォーカスが移る', async () => {
+    const widget = new TweetWidget();
+    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await new Promise(res => setTimeout(res, 0));
+    await widget.submitPost('grand');
+    const grandId = widget.currentSettings.posts[0].id;
+    await widget.submitReply('parent', grandId);
+    const parentId = widget.currentSettings.posts[0].id;
+    await widget.submitReply('child', parentId);
+    const childId = widget.currentSettings.posts[0].id;
+    widget.navigateToDetail(childId);
+    await widget.deleteThread(parentId);
+    expect(widget.detailPostId).toBe(grandId);
+  });
+
   it('updatePostPropertyで任意のプロパティが更新される', async () => {
     const widget = new TweetWidget();
     widget.create(dummyConfig, dummyApp, dummyPlugin);

--- a/__tests__/widgets/tweetWidget.test.ts
+++ b/__tests__/widgets/tweetWidget.test.ts
@@ -169,6 +169,19 @@ describe('TweetWidget', () => {
     expect(widget.currentSettings.posts.find(p => p.id === postId)).toBeUndefined();
   });
 
+  it('詳細表示中の投稿を削除すると親にフォーカスが移る', async () => {
+    const widget = new TweetWidget();
+    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await new Promise(res => setTimeout(res, 0));
+    await widget.submitPost('parent');
+    const parentId = widget.currentSettings.posts[0].id;
+    await widget.submitReply('child', parentId);
+    const childId = widget.currentSettings.posts[0].id;
+    widget.navigateToDetail(childId);
+    await widget.deletePost(childId);
+    expect(widget.detailPostId).toBe(parentId);
+  });
+
   it('updatePostPropertyで任意のプロパティが更新される', async () => {
     const widget = new TweetWidget();
     widget.create(dummyConfig, dummyApp, dummyPlugin);

--- a/src/widgets/tweetWidget/tweetWidget.ts
+++ b/src/widgets/tweetWidget/tweetWidget.ts
@@ -377,11 +377,14 @@ export class TweetWidget implements WidgetImplementation {
     public async deleteThread(rootId: string) {
         const threadIds = this.store.collectThreadIds(rootId);
         const posts = threadIds.map(id => this.store.getPostById(id)).filter(Boolean) as TweetWidgetPost[];
+        const rootPost = this.store.getPostById(rootId);
         this.store.deleteThread(rootId);
         for (const p of posts) {
             if (!p.deleted) this.plugin.updateTweetPostCount(p.created, -1);
         }
-        this.detailPostId = null;
+        if (threadIds.includes(this.detailPostId ?? '')) {
+            this.detailPostId = rootPost?.threadId ?? null;
+        }
         this.saveDataDebounced();
         this.ui.render();
     }

--- a/src/widgets/tweetWidget/tweetWidget.ts
+++ b/src/widgets/tweetWidget/tweetWidget.ts
@@ -354,6 +354,9 @@ export class TweetWidget implements WidgetImplementation {
             this.plugin.updateTweetPostCount(post.created, deleted ? -1 : 1);
         }
         this.store.updatePost(postId, { deleted });
+        if (deleted && this.detailPostId === postId) {
+            this.detailPostId = post?.threadId ?? null;
+        }
         this.saveDataDebounced();
         this.ui.scheduleRender();
     }
@@ -363,6 +366,9 @@ export class TweetWidget implements WidgetImplementation {
         this.store.deletePost(postId);
         if (post && !post.deleted) {
             this.plugin.updateTweetPostCount(post.created, -1);
+        }
+        if (this.detailPostId === postId) {
+            this.detailPostId = post?.threadId ?? null;
         }
         this.saveDataDebounced();
         this.ui.render();


### PR DESCRIPTION
## Summary
- keep tweet detail view open on the parent when deleting the focused post
- add regression test for deleting from detail view

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851635c0e988320bcbc87c7e476713d