### PR TITLE
Fix schedule timezone calculation

### DIFF
--- a/src/widgets/tweetWidget/scheduleUtils.ts
+++ b/src/widgets/tweetWidget/scheduleUtils.ts
@@ -11,8 +11,17 @@ export function computeNextTime(opts: ScheduleOptions, from: Date = new Date()):
     const end = opts.endDate ? new Date(opts.endDate) : null;
     let base = new Date(from.getTime());
     if (start && base < start) base = new Date(start.getTime());
+    // use UTC timestamps to avoid timezone differences
     for (let i = 0; i < 366; i++) {
-        const d = new Date(base.getFullYear(), base.getMonth(), base.getDate() + i, opts.hour, opts.minute, 0, 0);
+        const d = new Date(Date.UTC(
+            base.getUTCFullYear(),
+            base.getUTCMonth(),
+            base.getUTCDate() + i,
+            opts.hour,
+            opts.minute,
+            0,
+            0,
+        ));
         if (d <= from) continue;
         if (start && d < start) continue;
         if (end && d > end) return null;


### PR DESCRIPTION
## Summary
- computeNextTime now creates dates in UTC
- added inline comment about timezone handling

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685169f212288320a489c83155dd6813