### PR TITLE
Refactor board and prewarm logic

### DIFF
--- a/src/boardManager.ts
+++ b/src/boardManager.ts
@@ -1,0 +1,167 @@
+// src/boardManager.ts
+import { App, Modal as ObsidianModal, Notice, Hotkey, Modifier, Setting } from 'obsidian';
+import type WidgetBoardPlugin from './main';
+import type { BoardConfiguration } from './interfaces';
+import { WidgetBoardModal } from './modal';
+
+export class BoardManager {
+    widgetBoardModals: Map<string, WidgetBoardModal> = new Map();
+    private registeredGroupCommandIds: string[] = [];
+
+    constructor(private plugin: WidgetBoardPlugin) {}
+
+    private get app(): App {
+        return this.plugin.app;
+    }
+
+    openBoardPicker(): void {
+        if (this.plugin.settings.boards.length === 0) {
+            new Notice('設定されているウィジェットボードがありません。設定画面から作成してください。');
+            return;
+        }
+        if (this.plugin.settings.boards.length === 1) {
+            this.openWidgetBoardById(this.plugin.settings.boards[0].id);
+            return;
+        }
+        const modal = new BoardPickerModal(this.app, this.plugin.settings.boards, (boardId) => {
+            this.openWidgetBoardById(boardId);
+        });
+        modal.open();
+    }
+
+    openWidgetBoardById(boardId: string): void {
+        const modal = this.widgetBoardModals.get(boardId);
+        if (modal) {
+            if (modal.isOpen || modal.isClosing) {
+                return;
+            } else {
+                this.widgetBoardModals.delete(boardId);
+                if (modal.modalEl && modal.modalEl.parentElement === document.body) {
+                    modal.modalEl.parentElement.removeChild(modal.modalEl);
+                }
+            }
+        }
+        const boardConfig = this.plugin.settings.boards.find(b => b.id === boardId);
+        if (!boardConfig) {
+            new Notice(`ID '${boardId}' のウィジェットボードが見つかりません。`);
+            return;
+        }
+        const validModes: string[] = Object.values(WidgetBoardModal.MODES);
+        if (!validModes.includes(boardConfig.defaultMode)) {
+            boardConfig.defaultMode = WidgetBoardModal.MODES.RIGHT_THIRD;
+        }
+        const newModal = new WidgetBoardModal(this.app, this.plugin, boardConfig);
+        this.widgetBoardModals.set(boardId, newModal);
+        const origOnClose = newModal.onClose.bind(newModal);
+        newModal.onClose = () => {
+            this.widgetBoardModals.delete(boardId);
+            origOnClose();
+        };
+        newModal.open();
+    }
+
+    toggleWidgetBoardById(boardId: string): void {
+        const modal = this.widgetBoardModals.get(boardId);
+        if (modal && modal.isOpen) {
+            modal.close();
+            return;
+        }
+        this.openWidgetBoardById(boardId);
+    }
+
+    closeWidgetBoardById(boardId: string): void {
+        const modal = this.widgetBoardModals.get(boardId);
+        if (modal && modal.isOpen) {
+            modal.close();
+        }
+    }
+
+    registerAllBoardCommands(): void {
+        if (typeof this.plugin.removeCommand === 'function') {
+            this.registeredGroupCommandIds.forEach(id => {
+                this.plugin.removeCommand(id);
+            });
+        }
+        this.registeredGroupCommandIds = [];
+        this.plugin.settings.boards.forEach(board => {
+            this.plugin.addCommand({
+                id: `toggle-widget-board-${board.id}`,
+                name: `ウィジェットボードをトグル: ${board.name}`,
+                callback: () => this.toggleWidgetBoardById(board.id)
+            });
+            this.plugin.addCommand({
+                id: `close-widget-board-${board.id}`,
+                name: `ウィジェットボードを閉じる: ${board.name}`,
+                callback: () => this.closeWidgetBoardById(board.id)
+            });
+        });
+        (this.plugin.settings.boardGroups || []).forEach(group => {
+            let hotkeys: Hotkey[] = [];
+            if (group.hotkey) {
+                const parts = group.hotkey.split('+');
+                if (parts.length > 1) {
+                    hotkeys = [{ modifiers: parts.slice(0, -1) as Modifier[], key: parts[parts.length - 1] }];
+                } else {
+                    hotkeys = [{ modifiers: [], key: group.hotkey }];
+                }
+            }
+            const cmdId = `open-board-group-${group.id}`;
+            this.plugin.addCommand({
+                id: cmdId,
+                name: `ボードグループをトグル: ${group.name}`,
+                hotkeys,
+                callback: () => {
+                    const anyOpen = (group.boardIds || []).some(boardId => {
+                        const modal = this.widgetBoardModals.get(boardId);
+                        return modal && modal.isOpen;
+                    });
+                    if (anyOpen) {
+                        (group.boardIds || [])
+                            .filter(boardId => {
+                                const modal = this.widgetBoardModals.get(boardId);
+                                return modal && modal.isOpen;
+                            })
+                            .forEach(boardId => {
+                                const modal = this.widgetBoardModals.get(boardId);
+                                if (modal) modal.close();
+                            });
+                    } else {
+                        (group.boardIds || []).forEach(boardId => {
+                            this.openWidgetBoardById(boardId);
+                        });
+                    }
+                }
+            });
+            this.registeredGroupCommandIds.push(cmdId);
+        });
+    }
+
+    hideAllBoards(): void {
+        this.widgetBoardModals.forEach(modal => {
+            if (modal.isOpen) modal.close();
+        });
+    }
+}
+
+class BoardPickerModal extends ObsidianModal {
+    constructor(app: App, private boards: BoardConfiguration[], private onChoose: (boardId: string) => void) {
+        super(app);
+    }
+    onOpen() {
+        const { contentEl } = this;
+        contentEl.empty();
+        new Setting(contentEl).setName('ウィジェットボードを選択').setHeading();
+        const listEl = contentEl.createDiv({ cls: 'widget-board-picker-list' });
+        this.boards.forEach(board => {
+            const boardItemEl = listEl.createDiv({ cls: 'widget-board-picker-item' });
+            boardItemEl.setText(board.name);
+            boardItemEl.onClickEvent(() => {
+                this.onChoose(board.id);
+                this.close();
+            });
+        });
+    }
+    onClose() {
+        this.contentEl.empty();
+    }
+}

--- a/src/prewarm.ts
+++ b/src/prewarm.ts
@@ -1,0 +1,148 @@
+// src/prewarm.ts
+import { Notice, App, Component, TFile } from 'obsidian';
+import type WidgetBoardPlugin from './main';
+import { TweetRepository } from './widgets/tweetWidget';
+import { MemoWidgetSettings } from './widgets/memo';
+import { FileViewWidgetSettings } from './widgets/file-view';
+import { renderMarkdownBatchWithCache } from './utils/renderMarkdownBatch';
+import { getDateKey, getWeekRange } from './utils';
+
+export class PrewarmManager {
+    tweetPostCountCache: Record<string, number> = {};
+
+    constructor(private plugin: WidgetBoardPlugin) {}
+
+    private get app(): App {
+        return this.plugin.app;
+    }
+
+    async initTweetPostCountCache() {
+        const dbPath = this.plugin.settings.baseFolder
+            ? `${this.plugin.settings.baseFolder.replace(/\/$/, '')}/tweets.json`
+            : 'tweets.json';
+        const repo = new TweetRepository(this.app, dbPath);
+        const tweetSettings = await repo.load();
+        this.tweetPostCountCache = {};
+        for (const p of tweetSettings.posts || []) {
+            if (p.deleted) continue;
+            const key = getDateKey(new Date(p.created));
+            this.tweetPostCountCache[key] = (this.tweetPostCountCache[key] || 0) + 1;
+        }
+    }
+
+    updateTweetPostCount(created: number, delta: number) {
+        const key = getDateKey(new Date(created));
+        this.tweetPostCountCache[key] = (this.tweetPostCountCache[key] || 0) + delta;
+        if (this.tweetPostCountCache[key] <= 0) {
+            delete this.tweetPostCountCache[key];
+        }
+        this.plugin.tweetChartDirty = true;
+    }
+
+    getTweetPostCounts(days: string[]): number[] {
+        return days.map(d => this.tweetPostCountCache[d] || 0);
+    }
+
+    async prewarmAllWidgetMarkdownCache() {
+        const MAX_PREWARM_ENTRIES = 50;
+        try {
+            new Notice('キャッシュ中…');
+            const dbPath = this.plugin.settings.baseFolder
+                ? `${this.plugin.settings.baseFolder.replace(/\/$/, '')}/tweets.json`
+                : 'tweets.json';
+            const repo = new TweetRepository(this.app, dbPath);
+            const tweetSettings = await repo.load();
+            const tweetPosts = (tweetSettings.posts || []).slice(0, MAX_PREWARM_ENTRIES);
+
+            const memoContents: string[] = [];
+            const fileViewFiles: string[] = [];
+            for (const board of this.plugin.settings.boards) {
+                for (const widget of board.widgets) {
+                    if (widget.type === 'memo') {
+                        const settings = widget.settings as MemoWidgetSettings;
+                        if (settings?.memoContent) {
+                            memoContents.push(settings.memoContent);
+                        }
+                    }
+                    if (widget.type === 'file-view-widget') {
+                        const settings = widget.settings as FileViewWidgetSettings;
+                        if (settings?.fileName) {
+                            fileViewFiles.push(settings.fileName);
+                        }
+                    }
+                }
+            }
+            memoContents.splice(MAX_PREWARM_ENTRIES);
+            fileViewFiles.splice(MAX_PREWARM_ENTRIES);
+
+            async function loadReflectionSummary(type: 'today' | 'week', dateKey: string, app: App): Promise<string | null> {
+                const path = 'data.json';
+                try {
+                    const raw = await app.vault.adapter.read(path);
+                    const data = JSON.parse(raw);
+                    if (data.reflectionSummaries && data.reflectionSummaries[type]?.date === dateKey) {
+                        return data.reflectionSummaries[type].summary;
+                    }
+                } catch {
+                }
+                return null;
+            }
+            const todayKey = getDateKey(new Date());
+            const [, weekEnd] = getWeekRange(this.plugin.settings.weekStartDay);
+            const weekKey = weekEnd;
+            const todaySummary = await loadReflectionSummary('today', todayKey, this.app);
+            const weekSummary = await loadReflectionSummary('week', weekKey, this.app);
+
+            let tweetIndex = 0, memoIndex = 0, fileIndex = 0;
+            let reflectionIndex = 0;
+            const reflectionSummaries = [todaySummary, weekSummary].filter(Boolean).slice(0, MAX_PREWARM_ENTRIES) as string[];
+            const batchSize = 3;
+            const schedule = (cb: () => void) => {
+                const w = window as Window & {
+                    requestIdleCallback?: (callback: IdleRequestCallback) => number;
+                };
+                if (typeof w.requestIdleCallback === 'function') {
+                    w.requestIdleCallback(cb);
+                } else {
+                    requestAnimationFrame(cb);
+                }
+            };
+            const processBatch = async () => {
+                const tweetEnd = Math.min(tweetIndex + batchSize, tweetPosts.length);
+                for (; tweetIndex < tweetEnd; tweetIndex++) {
+                    const post = tweetPosts[tweetIndex];
+                    await renderMarkdownBatchWithCache(post.text, document.createElement('div'), '', new Component());
+                }
+                const memoEnd = Math.min(memoIndex + batchSize, memoContents.length);
+                for (; memoIndex < memoEnd; memoIndex++) {
+                    await renderMarkdownBatchWithCache(memoContents[memoIndex], document.createElement('div'), '', new Component());
+                }
+                const fileEnd = Math.min(fileIndex + batchSize, fileViewFiles.length);
+                for (; fileIndex < fileEnd; fileIndex++) {
+                    const file = this.app.vault.getAbstractFileByPath(fileViewFiles[fileIndex]);
+                    if (file && file instanceof TFile) {
+                        const content = await this.app.vault.read(file);
+                        await renderMarkdownBatchWithCache(content, document.createElement('div'), file.path, new Component());
+                    }
+                }
+                const reflectionEnd = Math.min(reflectionIndex + batchSize, reflectionSummaries.length);
+                for (; reflectionIndex < reflectionEnd; reflectionIndex++) {
+                    await renderMarkdownBatchWithCache(reflectionSummaries[reflectionIndex], document.createElement('div'), '', new Component());
+                }
+                if (
+                    tweetIndex < tweetPosts.length ||
+                    memoIndex < memoContents.length ||
+                    fileIndex < fileViewFiles.length ||
+                    reflectionIndex < reflectionSummaries.length
+                ) {
+                    schedule(processBatch);
+                } else {
+                    new Notice('キャッシュ完了');
+                }
+            };
+            schedule(processBatch);
+        } catch (e) {
+            console.error('プリウォーム中にエラー:', e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract board modal logic to `boardManager.ts`
- extract prewarm and tweet stat logic to `prewarm.ts`
- keep main plugin class lean and delegate to new modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68558c8d92448320a578efcad0730ed4