### PR TITLE
Add LLMManager tests

### DIFF
--- a/__tests__/utils/llmManager.test.ts
+++ b/__tests__/utils/llmManager.test.ts
@@ -1,0 +1,30 @@
+import { LLMManager, LLMProvider } from '../../src/llm/llmManager';
+
+describe('LLMManager', () => {
+  test('generateReplyWithDefault uses gemini provider when registered', async () => {
+    const geminiProvider: LLMProvider = {
+      id: 'gemini',
+      name: 'Gemini',
+      generateReply: jest.fn().mockResolvedValue('ok'),
+    };
+    const otherProvider: LLMProvider = {
+      id: 'other',
+      name: 'Other',
+      generateReply: jest.fn().mockResolvedValue('other'),
+    };
+
+    const manager = new LLMManager();
+    manager.register(geminiProvider);
+    manager.register(otherProvider);
+
+    const result = await manager.generateReplyWithDefault('hello', {});
+    expect(result).toBe('ok');
+    expect(geminiProvider.generateReply).toHaveBeenCalledWith('hello', {});
+    expect(otherProvider.generateReply).not.toHaveBeenCalled();
+  });
+
+  test('generateReplyWithDefault throws when gemini provider not registered', async () => {
+    const manager = new LLMManager();
+    await expect(manager.generateReplyWithDefault('hi', {})).rejects.toThrow('LLM provider not found');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for LLMManager to ensure gemini provider is used by default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68558c8f2f308320803da0ad207262e5