### PR TITLE
Refactor Pomodoro widget into modular components

### DIFF
--- a/__tests__/widgets/pomodoroWidget.test.ts
+++ b/__tests__/widgets/pomodoroWidget.test.ts
@@ -172,7 +172,7 @@ describe('PomodoroWidget 詳細テスト', () => {
         state: 'running',
         close: jest.fn(),
       };
-      (widget as any).audioContext = ctxMock;
+      (widget as any).soundPlayer.audioContext = ctxMock;
       // default_beep
       (widget as any).currentSettings.notificationSound = 'default_beep';
       expect(() => (widget as any).playSoundNotification()).not.toThrow();

--- a/src/widgets/pomodoro/index.ts
+++ b/src/widgets/pomodoro/index.ts
@@ -1,10 +1,13 @@
 // src/widgets/pomodoroWidget.ts
-import { App, Notice, setIcon } from 'obsidian';
+import { App, Notice } from "obsidian";
+import PomodoroSoundPlayer from "./sound";
+import PomodoroSessionLogger from "./logger";
+import PomodoroView from "./view";
 import type { WidgetConfig, WidgetImplementation } from '../../interfaces';
 import type WidgetBoardPlugin from '../../main'; // main.ts の WidgetBoardPlugin クラスをインポート
 import { PomodoroMemoWidget } from './pomodoroMemoWidget';
 import { debugLog } from '../../utils/logger';
-import { applyWidgetSize, createWidgetContainer, pad2, getDateKeyLocal } from '../../utils';
+import { pad2, getDateKeyLocal } from '../../utils';
 
 // --- 通知音の種類の型定義 ---
 export type PomodoroSoundType = 'off' | 'default_beep' | 'bell' | 'chime';
@@ -72,20 +75,20 @@ export class PomodoroWidget implements WidgetImplementation {
     private pomodorosCompletedInCycle: number = 0;
     private initialized: boolean;
 
-    private widgetEl!: HTMLElement;
-    private timeDisplayEl!: HTMLElement;
-    private statusDisplayEl!: HTMLElement;
-    private cycleDisplayEl!: HTMLElement;
-    private startPauseButton!: HTMLButtonElement;
-    private resetButton!: HTMLButtonElement;
-    private nextButton!: HTMLButtonElement;
-
+    private view!: PomodoroView;
+    public widgetEl!: HTMLElement;
+    public timeDisplayEl!: HTMLElement;
+    public statusDisplayEl!: HTMLElement;
+    public cycleDisplayEl!: HTMLElement;
+    public startPauseButton!: HTMLButtonElement;
+    public resetButton!: HTMLButtonElement;
+    public nextButton!: HTMLButtonElement;
     private memoWidget: PomodoroMemoWidget | null = null;
+    private soundPlayer!: PomodoroSoundPlayer;
+    private sessionLogger!: PomodoroSessionLogger;
 
     private currentSettings!: PomodoroSettings;
     private lastConfiguredId?: string;
-    private audioContext: AudioContext | null = null;
-    private currentAudioElement: HTMLAudioElement | null = null;
 
     private static widgetInstances: Map<string, PomodoroWidget> = new Map();
     private static widgetStates: Map<string, PomodoroState> = new Map();
@@ -99,13 +102,6 @@ export class PomodoroWidget implements WidgetImplementation {
 
     private needsRender = false;
 
-    private _prevDisplay: {
-        timeStr?: string;
-        isRunning?: boolean;
-        statusText?: string;
-        cycleText?: string;
-        resetIconSet?: boolean;
-    } = {};
 
     /**
      * インスタンス初期化
@@ -113,6 +109,7 @@ export class PomodoroWidget implements WidgetImplementation {
     constructor() {
         this.initialized = false;
         this.currentPomodoroSet = 'work';
+        this.soundPlayer = new PomodoroSoundPlayer();
     }
 
     public getWidgetId(): string | undefined {
@@ -120,21 +117,7 @@ export class PomodoroWidget implements WidgetImplementation {
     }
 
     private applyBackground(imageUrl?: string) {
-        if (!this.widgetEl) return;
-        const trimmedUrl = imageUrl?.trim();
-        if (trimmedUrl) {
-            this.widgetEl.style.backgroundImage = `url("${trimmedUrl}")`;
-            this.widgetEl.style.backgroundSize = "cover";
-            this.widgetEl.style.backgroundPosition = "center";
-            this.widgetEl.style.backgroundRepeat = "no-repeat";
-            this.widgetEl.classList.add('has-background-image');
-        } else {
-            this.widgetEl.style.backgroundImage = "";
-            this.widgetEl.style.backgroundSize = "";
-            this.widgetEl.style.backgroundPosition = "";
-            this.widgetEl.style.backgroundRepeat = "";
-            this.widgetEl.classList.remove('has-background-image');
-        }
+        this.view?.applyBackground(imageUrl);
     }
 
     private async renderMemo(markdownContent?: string) {
@@ -282,6 +265,7 @@ export class PomodoroWidget implements WidgetImplementation {
         this.config = config;
         this.app = app;
         this.plugin = plugin;
+        this.sessionLogger = new PomodoroSessionLogger(app, plugin);
 
         if (!this.initialized) {
             this.currentSettings = { ...DEFAULT_POMODORO_SETTINGS, ...(config.settings || {}) };
@@ -309,31 +293,20 @@ export class PomodoroWidget implements WidgetImplementation {
         }
         config.settings = this.currentSettings;
 
-        const { widgetEl, titleEl } = createWidgetContainer(config, 'pomodoro-timer-widget');
-        this.widgetEl = widgetEl;
+        this.view = new PomodoroView();
+        const { widgetEl, contentEl } = this.view.create(config);
+        this.widgetEl = this.view.widgetEl;
+        this.timeDisplayEl = this.view.timeDisplayEl;
+        this.statusDisplayEl = this.view.statusDisplayEl;
+        this.cycleDisplayEl = this.view.cycleDisplayEl;
+        this.startPauseButton = this.view.startPauseButton;
+        this.resetButton = this.view.resetButton;
+        this.nextButton = this.view.nextButton;
         this.applyBackground(this.currentSettings.backgroundImageUrl);
-        if (titleEl) {
-            titleEl.textContent = this.config.title || "ポモドーロタイマー";
-            if (!this.config.title || this.config.title.trim() === "") {
-                titleEl.style.display = 'none';
-            } else {
-                titleEl.style.display = '';
-            }
-        }
 
-        const contentEl = this.widgetEl.createDiv({ cls: 'widget-content' });
-        this.timeDisplayEl = contentEl.createDiv({ cls: 'pomodoro-time-display' });
-        this.statusDisplayEl = contentEl.createDiv({ cls: 'pomodoro-status-display' });
-        this.cycleDisplayEl = contentEl.createDiv({ cls: 'pomodoro-cycle-display' });
-
-        const controlsEl = contentEl.createDiv({ cls: 'pomodoro-controls' });
-        this.startPauseButton = controlsEl.createEl('button', { cls: 'pomodoro-start-pause' });
-        this.resetButton = controlsEl.createEl('button', { cls: 'pomodoro-reset' });
-        this.nextButton = controlsEl.createEl('button', { cls: 'pomodoro-next' });
-
-        this.startPauseButton.onClickEvent(() => this.toggleStartPause());
-        this.resetButton.onClickEvent(() => this.resetCurrentTimerConfirm());
-        this.nextButton.onClickEvent(() => this.skipToNextSessionConfirm());
+        this.view.startPauseButton.onClickEvent(() => this.toggleStartPause());
+        this.view.resetButton.onClickEvent(() => this.resetCurrentTimerConfirm());
+        this.view.nextButton.onClickEvent(() => this.skipToNextSessionConfirm());
         
         // --- メモウィジェットを生成 ---
         this.memoWidget = new PomodoroMemoWidget(app, contentEl, { memoContent: this.currentSettings.memoContent }, async (newMemo: string) => {
@@ -382,10 +355,8 @@ export class PomodoroWidget implements WidgetImplementation {
         this.initialized = true;
         this.lastConfiguredId = newConfigId;
 
-        // 追加: YAMLで大きさ指定があれば反映
-        applyWidgetSize(this.widgetEl, config.settings as { width?: string; height?: string } | null);
-
-        return this.widgetEl;
+        // 追加: YAMLで大きさ指定があれば反映 (view側で処理)
+        return this.view.widgetEl;
     }
 
     private formatTime(totalSeconds: number): string {
@@ -398,42 +369,13 @@ export class PomodoroWidget implements WidgetImplementation {
      * UIを差分更新（値が変化した場合のみDOMを更新）
      */
     private updateDisplay() {
-        if (!this.widgetEl || !this.timeDisplayEl || !this.startPauseButton || !this.resetButton || !this.nextButton || !this.statusDisplayEl || !this.cycleDisplayEl) return;
-
-        const prev = this._prevDisplay;
-        const timeStr = this.formatTime(this.remainingTime);
-        if (prev.timeStr !== timeStr) {
-            this.timeDisplayEl.textContent = timeStr;
-            prev.timeStr = timeStr;
-        }
-        const isRunning = this.isRunning;
-        if (prev.isRunning !== isRunning) {
-            setIcon(this.startPauseButton, isRunning ? 'pause' : 'play');
-            this.startPauseButton.setAttribute('aria-label', isRunning ? '一時停止' : '開始');
-            prev.isRunning = isRunning;
-        }
-        if (!prev.resetIconSet) {
-            setIcon(this.resetButton, 'rotate-ccw');
-            this.resetButton.setAttribute('aria-label', 'リセット');
-            setIcon(this.nextButton, 'skip-forward');
-            this.nextButton.setAttribute('aria-label', '次のセッションへ');
-            prev.resetIconSet = true;
-        }
-        let statusText = '';
-        switch (this.currentPomodoroSet) {
-            case 'work': statusText = `作業中 (${this.currentSettings.workMinutes}分)`; break;
-            case 'shortBreak': statusText = `短い休憩 (${this.currentSettings.shortBreakMinutes}分)`; break;
-            case 'longBreak': statusText = `長い休憩 (${this.currentSettings.longBreakMinutes}分)`; break;
-        }
-        if (prev.statusText !== statusText) {
-            this.statusDisplayEl.textContent = statusText;
-            prev.statusText = statusText;
-        }
-        const cycleText = `現在のサイクル: ${this.pomodorosCompletedInCycle} / ${this.currentSettings.pomodorosUntilLongBreak}`;
-        if (prev.cycleText !== cycleText) {
-            this.cycleDisplayEl.textContent = cycleText;
-            prev.cycleText = cycleText;
-        }
+        this.view.updateDisplay({
+            remainingTime: this.remainingTime,
+            isRunning: this.isRunning,
+            currentPomodoroSet: this.currentPomodoroSet,
+            pomodorosCompletedInCycle: this.pomodorosCompletedInCycle,
+            settings: this.currentSettings,
+        });
     }
 
     private toggleStartPause() { if (this.isRunning) this.pauseTimer(); else this.startTimer(); }
@@ -451,7 +393,7 @@ export class PomodoroWidget implements WidgetImplementation {
         PomodoroWidget.ensureGlobalInterval();
         this.updateDisplay();
         this.currentSessionStartTime = new Date();
-        const statusText = this.statusDisplayEl?.textContent?.split('(')[0].trim() || '作業';
+        const statusText = this.view.statusDisplayEl?.textContent?.split('(')[0].trim() || '作業';
         new Notice(`${statusText} を開始しました。`);
     }
 
@@ -467,7 +409,7 @@ export class PomodoroWidget implements WidgetImplementation {
         });
         PomodoroWidget.clearGlobalIntervalIfNoneRunning();
         this.updateDisplay();
-        const statusText = this.statusDisplayEl?.textContent?.split('(')[0].trim() || '作業';
+        const statusText = this.view.statusDisplayEl?.textContent?.split('(')[0].trim() || '作業';
         new Notice(`${statusText} を一時停止しました。`);
     }
 
@@ -483,7 +425,7 @@ export class PomodoroWidget implements WidgetImplementation {
             // 1回目は通常リセット
             this.pauseTimer();
             this.resetTimerState(this.currentPomodoroSet, false); // サイクルは維持
-            const statusText = this.statusDisplayEl?.textContent?.split('(')[0].trim() || '作業';
+            const statusText = this.view.statusDisplayEl?.textContent?.split('(')[0].trim() || '作業';
             new Notice(`${statusText} をリセットしました。\n（サイクル数もリセットするにはもう一度すぐ押してください）`);
             this.lastResetClickTime = now;
         }
@@ -513,64 +455,8 @@ export class PomodoroWidget implements WidgetImplementation {
         const globalSound = this.plugin.settings.pomodoroNotificationSound;
         const globalVolume = this.plugin.settings.pomodoroNotificationVolume;
         const soundType = globalSound ?? this.currentSettings.notificationSound;
-        const volume = (globalVolume !== undefined ? globalVolume : this.currentSettings.notificationVolume);
-
-        if (soundType === 'off') return;
-
-        // 既存の音声を停止
-        if (this.currentAudioElement) {
-            this.currentAudioElement.pause(); this.currentAudioElement.currentTime = 0; this.currentAudioElement = null;
-        }
-        // AudioContextが再利用可能なら再利用、そうでなければ新規生成
-        if (!this.audioContext || this.audioContext.state === 'closed') {
-            const Ctor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
-            this.audioContext = new Ctor();
-        }
-        const ctx = this.audioContext;
-        try {
-            if (soundType === 'default_beep') {
-                const osc = ctx.createOscillator();
-                const gain = ctx.createGain();
-                osc.type = 'sine';
-                osc.frequency.setValueAtTime(880, ctx.currentTime);
-                gain.gain.setValueAtTime(volume, ctx.currentTime);
-                gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.7);
-                osc.connect(gain); gain.connect(ctx.destination);
-                osc.start(ctx.currentTime);
-                osc.stop(ctx.currentTime + 0.7);
-                osc.onended = () => { ctx.close().catch(() => {}); this.audioContext = null; };
-            } else if (soundType === 'bell') {
-                const osc1 = ctx.createOscillator();
-                const osc2 = ctx.createOscillator();
-                const gain = ctx.createGain();
-                osc1.type = 'triangle';
-                osc2.type = 'triangle';
-                osc1.frequency.setValueAtTime(880, ctx.currentTime);
-                osc2.frequency.setValueAtTime(1320, ctx.currentTime);
-                gain.gain.setValueAtTime(volume, ctx.currentTime);
-                gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.8);
-                osc1.connect(gain); osc2.connect(gain); gain.connect(ctx.destination);
-                osc1.start(ctx.currentTime); osc2.start(ctx.currentTime);
-                osc1.stop(ctx.currentTime + 0.8); osc2.stop(ctx.currentTime + 0.8);
-                osc2.detune.setValueAtTime(5, ctx.currentTime + 0.2);
-                osc1.onended = () => { ctx.close().catch(() => {}); this.audioContext = null; };
-            } else if (soundType === 'chime') {
-                const notes = [523.25, 659.25, 784.0];
-                const now = ctx.currentTime;
-                notes.forEach((freq, i) => {
-                    const osc = ctx.createOscillator();
-                    const gain = ctx.createGain();
-                    osc.type = 'sine';
-                    osc.frequency.setValueAtTime(freq, now + i * 0.18);
-                    gain.gain.setValueAtTime(volume, now + i * 0.18);
-                    gain.gain.exponentialRampToValueAtTime(0.0001, now + i * 0.18 + 0.22);
-                    osc.connect(gain); gain.connect(ctx.destination);
-                    osc.start(now + i * 0.18);
-                    osc.stop(now + i * 0.18 + 0.22);
-                    if (i === notes.length - 1) osc.onended = () => { ctx.close().catch(() => {}); this.audioContext = null; };
-                });
-            }
-        } catch (e) { new Notice('音声の再生に失敗しました'); console.error("Error playing sound:", e); }
+        const volume = globalVolume !== undefined ? globalVolume : this.currentSettings.notificationVolume;
+        this.soundPlayer.play(soundType, volume);
     }
 
     private async handleSessionEnd() {
@@ -724,12 +610,8 @@ export class PomodoroWidget implements WidgetImplementation {
         const widgetIdLog = `[${this.config?.id || 'PomodoroWidget'}]`;
         if (this.timerId) { clearInterval(this.timerId); this.timerId = null; }
         this.isRunning = false;
-        if (this.audioContext && this.audioContext.state !== 'closed') {
-            this.audioContext.close().catch(err => console.error(`${widgetIdLog} Error closing AudioContext:`, err));
-            this.audioContext = null;
-        }
-        if (this.currentAudioElement) {
-            this.currentAudioElement.pause(); this.currentAudioElement.src = ""; this.currentAudioElement = null;
+        if (this.soundPlayer) {
+            this.soundPlayer.unload();
         }
         (this.constructor as typeof PomodoroWidget).widgetInstances.delete(this.config?.id);
         (this.constructor as typeof PomodoroWidget).widgetStates.delete(this.config?.id);
@@ -844,115 +726,10 @@ export class PomodoroWidget implements WidgetImplementation {
         this.widgetInstances.clear();
         this.widgetStates.clear();
     }
-
     private async exportSessionLogs(format: PomodoroExportFormat) {
-        debugLog(this.plugin, 'exportSessionLogs called', this.sessionLogs);
-        if (this.sessionLogs.length === 0) {
-            new Notice("エクスポートするログがありません。");
-            return;
-        }
-        let content = '';
-        let ext = '';
-        if (format === 'csv') {
-            ext = 'csv';
-        } else if (format === 'json') {
-            ext = 'json';
-        } else if (format === 'markdown') {
-            ext = 'md';
-        } else {
-            return; // 'none' or unknown format
-        }
-        const pluginFolder = this.app.vault.configDir + '/plugins/' + this.plugin.manifest.id;
-        const logsFolder = pluginFolder + '/logs';
-        const filePath = logsFolder + `/pomodoro-log.${ext}`;
-        let allLogs: SessionLog[] = [];
-        try {
-            // logsフォルダがなければ作成
-            const logsFolderExists = await this.app.vault.adapter.exists(logsFolder);
-            if (!logsFolderExists) {
-                await this.app.vault.adapter.mkdir(logsFolder);
-            }
-            // 既存ファイルがあれば内容を読み込む
-            const fileExists = await this.app.vault.adapter.exists(filePath);
-            if (fileExists) {
-                const existing = await this.app.vault.adapter.read(filePath);
-                if (format === 'csv') {
-                    const lines = existing.split('\n').filter(l => l.trim() !== '');
-                    if (lines.length > 1) {
-                        for (let i = 1; i < lines.length; i++) {
-                            // カラム順: date, start, end, sessionType, memo
-                            const [date, start, end, sessionType, memo] = lines[i].split(/,(?=(?:[^"]*"[^"]*")*[^"]*$)/);
-                            allLogs.push({
-                                date: date || '',
-                                start: start || '',
-                                end: end || '',
-                                sessionType: (sessionType as 'work'|'shortBreak'|'longBreak') || 'work',
-                                memo: memo ? memo.replace(/^"|"$/g, '').replace(/""/g, '"') : '',
-                            });
-                        }
-                    }
-                } else if (format === 'json') {
-                    try {
-                        const parsed = JSON.parse(existing);
-                        if (Array.isArray(parsed)) {
-                            allLogs = parsed;
-                        } else {
-                            allLogs = [];
-                        }
-                    } catch {
-                        allLogs = [];
-                    }
-                } else if (format === 'markdown') {
-                    const lines = existing.split('\n').filter(l => l.trim() !== '');
-                    if (lines.length > 2) {
-                        for (let i = 2; i < lines.length; i++) {
-                            // 区切り文字'|'で分割し、両端の空白を除去
-                            const cols = lines[i].split('|').map(s => s.trim());
-                            // | date | start | end | sessionType | memo |
-                            if (cols.length >= 6) {
-                                // 0:空, 1:date, 2:start, 3:end, 4:sessionType, 5:memo, ...
-                                // memo列は5番目以降を結合し、両端の空白とパイプを除去
-                                let memo = cols.slice(5).join('|');
-                                memo = memo.replace(/^\|+/, '').replace(/\|+$/, '').trim();
-                                allLogs.push({
-                                    date: cols[1],
-                                    start: cols[2],
-                                    end: cols[3],
-                                    sessionType: (cols[4] as 'work'|'shortBreak'|'longBreak') || 'work',
-                                    memo: memo,
-                                });
-                            }
-                        }
-                    }
-                }
-            }
-            // 新規ログを追加
-            allLogs = allLogs.concat(this.sessionLogs);
-            // 重複排除（date, start, end, memoが全て一致するものは1つだけ）
-            // allLogs = allLogs.filter((log, idx, arr) =>
-            //     arr.findIndex(l => l.date === log.date && l.start === log.start && l.end === log.end && l.memo === log.memo) === idx
-            // );
-            // 保存内容を生成
-            if (format === 'csv') {
-                // BOM付きでExcel等でも文字化けしないように
-                content = '\uFEFFdate,start,end,sessionType,memo\n' + allLogs.map(log => {
-                    const safeMemo = (log.memo || '').replace(/\r?\n/g, '\\n').replace(/"/g, '""');
-                    return `${log.date},${log.start},${log.end},${log.sessionType},"${safeMemo}"`;
-                }).join('\n');
-            } else if (format === 'json') {
-                content = JSON.stringify(allLogs, null, 2);
-            } else if (format === 'markdown') {
-                content = '| date | start | end | sessionType | memo |\n|---|---|---|---|---|\n' + allLogs.map(log => 
-                    `| ${log.date} | ${log.start} | ${log.end} | ${log.sessionType} | ${(log.memo || '').replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>')} |`
-                ).join('\n');
-            }
-            await this.app.vault.adapter.write(filePath, content);
-            new Notice(`ポモドーロログを ${filePath} に保存しました。`);
-            this.sessionLogs = [];
-        } catch (e) {
-            new Notice('ログのエクスポートに失敗しました');
-            console.error("Error exporting session logs:", e);
-        }
+        debugLog(this.plugin, "exportSessionLogs called", this.sessionLogs);
+        await this.sessionLogger.exportLogs(this.sessionLogs, format);
+        this.sessionLogs = [];
     }
 
     private scheduleRender() {

--- a/src/widgets/pomodoro/logger.ts
+++ b/src/widgets/pomodoro/logger.ts
@@ -1,0 +1,96 @@
+import { Notice } from 'obsidian';
+import type { App } from 'obsidian';
+import type WidgetBoardPlugin from '../../main';
+import type { PomodoroExportFormat, SessionLog } from './index';
+
+export class PomodoroSessionLogger {
+  constructor(private app: App, private plugin: WidgetBoardPlugin) {}
+
+  async exportLogs(sessionLogs: SessionLog[], format: PomodoroExportFormat): Promise<void> {
+    if (sessionLogs.length === 0) {
+      new Notice('エクスポートするログがありません。');
+      return;
+    }
+
+    let content = '';
+    let ext = '';
+    if (format === 'csv') ext = 'csv';
+    else if (format === 'json') ext = 'json';
+    else if (format === 'markdown') ext = 'md';
+    else return;
+
+    const pluginFolder = this.app.vault.configDir + '/plugins/' + this.plugin.manifest.id;
+    const logsFolder = pluginFolder + '/logs';
+    const filePath = logsFolder + `/pomodoro-log.${ext}`;
+    let allLogs: SessionLog[] = [];
+    try {
+      const logsFolderExists = await this.app.vault.adapter.exists(logsFolder);
+      if (!logsFolderExists) {
+        await this.app.vault.adapter.mkdir(logsFolder);
+      }
+      const fileExists = await this.app.vault.adapter.exists(filePath);
+      if (fileExists) {
+        const existing = await this.app.vault.adapter.read(filePath);
+        if (format === 'csv') {
+          const lines = existing.split('\n').filter(l => l.trim() !== '');
+          if (lines.length > 1) {
+            for (let i = 1; i < lines.length; i++) {
+              const [date, start, end, sessionType, memo] = lines[i].split(/,(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/);
+              allLogs.push({
+                date: date || '',
+                start: start || '',
+                end: end || '',
+                sessionType: (sessionType as any) || 'work',
+                memo: memo ? memo.replace(/^\"|\"$/g, '').replace(/\"\"/g, '"') : '',
+              });
+            }
+          }
+        } else if (format === 'json') {
+          try {
+            const parsed = JSON.parse(existing);
+            if (Array.isArray(parsed)) allLogs = parsed; else allLogs = [];
+          } catch {
+            allLogs = [];
+          }
+        } else if (format === 'markdown') {
+          const lines = existing.split('\n').filter(l => l.trim() !== '');
+          if (lines.length > 2) {
+            for (let i = 2; i < lines.length; i++) {
+              const cols = lines[i].split('|').map(s => s.trim());
+              if (cols.length >= 6) {
+                let memo = cols.slice(5).join('|');
+                memo = memo.replace(/^\|+/, '').replace(/\|+$/, '').trim();
+                allLogs.push({
+                  date: cols[1],
+                  start: cols[2],
+                  end: cols[3],
+                  sessionType: (cols[4] as any) || 'work',
+                  memo: memo,
+                });
+              }
+            }
+          }
+        }
+      }
+      allLogs = allLogs.concat(sessionLogs);
+      if (format === 'csv') {
+        content = '\uFEFFdate,start,end,sessionType,memo\n' + allLogs.map(log => {
+          const safeMemo = (log.memo || '').replace(/\r?\n/g, '\\n').replace(/\"/g, '""');
+          return `${log.date},${log.start},${log.end},${log.sessionType},"${safeMemo}"`;
+        }).join('\n');
+      } else if (format === 'json') {
+        content = JSON.stringify(allLogs, null, 2);
+      } else if (format === 'markdown') {
+        content = '| date | start | end | sessionType | memo |\n|---|---|---|---|---|\n' +
+          allLogs.map(log => `| ${log.date} | ${log.start} | ${log.end} | ${log.sessionType} | ${(log.memo || '').replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>')} |`).join('\n');
+      }
+      await this.app.vault.adapter.write(filePath, content);
+      new Notice(`ポモドーロログを ${filePath} に保存しました。`);
+    } catch (e) {
+      new Notice('ログのエクスポートに失敗しました');
+      console.error('Error exporting session logs:', e);
+    }
+  }
+}
+
+export default PomodoroSessionLogger;

--- a/src/widgets/pomodoro/sound.ts
+++ b/src/widgets/pomodoro/sound.ts
@@ -1,0 +1,101 @@
+import { Notice } from 'obsidian';
+import type { PomodoroSoundType } from './index';
+
+export class PomodoroSoundPlayer {
+  private audioContext: AudioContext | null = null;
+  private currentAudioElement: HTMLAudioElement | null = null;
+
+  play(soundType: PomodoroSoundType, volume: number) {
+    if (soundType === 'off') return;
+
+    if (this.currentAudioElement) {
+      this.currentAudioElement.pause();
+      this.currentAudioElement.currentTime = 0;
+      this.currentAudioElement = null;
+    }
+
+    if (!this.audioContext || this.audioContext.state === 'closed') {
+      const Ctor = (window as any).AudioContext || (window as any).webkitAudioContext;
+      this.audioContext = new Ctor();
+    }
+    const ctx = this.audioContext!;
+    try {
+      if (soundType === 'default_beep') {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(880, ctx.currentTime);
+        gain.gain.setValueAtTime(volume, ctx.currentTime);
+        gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.7);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start(ctx.currentTime);
+        osc.stop(ctx.currentTime + 0.7);
+        osc.onended = () => {
+          ctx.close().catch(() => {});
+          this.audioContext = null;
+        };
+      } else if (soundType === 'bell') {
+        const osc1 = ctx.createOscillator();
+        const osc2 = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc1.type = 'triangle';
+        osc2.type = 'triangle';
+        osc1.frequency.setValueAtTime(880, ctx.currentTime);
+        osc2.frequency.setValueAtTime(1320, ctx.currentTime);
+        gain.gain.setValueAtTime(volume, ctx.currentTime);
+        gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.8);
+        osc1.connect(gain);
+        osc2.connect(gain);
+        gain.connect(ctx.destination);
+        osc1.start(ctx.currentTime);
+        osc2.start(ctx.currentTime);
+        osc1.stop(ctx.currentTime + 0.8);
+        osc2.stop(ctx.currentTime + 0.8);
+        osc2.detune.setValueAtTime(5, ctx.currentTime + 0.2);
+        osc1.onended = () => {
+          ctx.close().catch(() => {});
+          this.audioContext = null;
+        };
+      } else if (soundType === 'chime') {
+        const notes = [523.25, 659.25, 784.0];
+        const now = ctx.currentTime;
+        notes.forEach((freq, i) => {
+          const osc = ctx.createOscillator();
+          const gain = ctx.createGain();
+          osc.type = 'sine';
+          osc.frequency.setValueAtTime(freq, now + i * 0.18);
+          gain.gain.setValueAtTime(volume, now + i * 0.18);
+          gain.gain.exponentialRampToValueAtTime(0.0001, now + i * 0.18 + 0.22);
+          osc.connect(gain);
+          gain.connect(ctx.destination);
+          osc.start(now + i * 0.18);
+          osc.stop(now + i * 0.18 + 0.22);
+          if (i === notes.length - 1) {
+            osc.onended = () => {
+              ctx.close().catch(() => {});
+              this.audioContext = null;
+            };
+          }
+        });
+      }
+    } catch (e) {
+      new Notice('音声の再生に失敗しました');
+      console.error('Error playing sound:', e);
+    }
+  }
+
+  unload() {
+    if (this.audioContext && this.audioContext.state !== 'closed') {
+      this.audioContext.close().catch(() => {});
+      this.audioContext = null;
+    }
+    if (this.currentAudioElement) {
+      this.currentAudioElement.pause();
+      this.currentAudioElement.currentTime = 0;
+      this.currentAudioElement = null;
+    }
+  }
+}
+
+export default PomodoroSoundPlayer;

--- a/src/widgets/pomodoro/view.ts
+++ b/src/widgets/pomodoro/view.ts
@@ -1,0 +1,104 @@
+import { setIcon } from 'obsidian';
+import type { WidgetConfig } from '../../interfaces';
+import { applyWidgetSize, createWidgetContainer, pad2 } from '../../utils';
+import type { PomodoroSettings } from './index';
+
+export class PomodoroView {
+  widgetEl!: HTMLElement;
+  timeDisplayEl!: HTMLElement;
+  statusDisplayEl!: HTMLElement;
+  cycleDisplayEl!: HTMLElement;
+  startPauseButton!: HTMLButtonElement;
+  resetButton!: HTMLButtonElement;
+  nextButton!: HTMLButtonElement;
+
+  private _prevDisplay: { timeStr?: string; isRunning?: boolean; statusText?: string; cycleText?: string; resetIconSet?: boolean } = {};
+
+  create(config: WidgetConfig): { widgetEl: HTMLElement; contentEl: HTMLElement } {
+    const { widgetEl, titleEl } = createWidgetContainer(config, 'pomodoro-timer-widget');
+    this.widgetEl = widgetEl;
+    if (titleEl) {
+      titleEl.textContent = config.title || 'ポモドーロタイマー';
+      if (!config.title || config.title.trim() === '') titleEl.style.display = 'none';
+    }
+    const contentEl = this.widgetEl.createDiv({ cls: 'widget-content' });
+    this.timeDisplayEl = contentEl.createDiv({ cls: 'pomodoro-time-display' });
+    this.statusDisplayEl = contentEl.createDiv({ cls: 'pomodoro-status-display' });
+    this.cycleDisplayEl = contentEl.createDiv({ cls: 'pomodoro-cycle-display' });
+    const controlsEl = contentEl.createDiv({ cls: 'pomodoro-controls' });
+    this.startPauseButton = controlsEl.createEl('button', { cls: 'pomodoro-start-pause' });
+    this.resetButton = controlsEl.createEl('button', { cls: 'pomodoro-reset' });
+    this.nextButton = controlsEl.createEl('button', { cls: 'pomodoro-next' });
+    applyWidgetSize(this.widgetEl, config.settings as { width?: string; height?: string } | null);
+    return { widgetEl, contentEl };
+  }
+
+  applyBackground(imageUrl?: string) {
+    if (!this.widgetEl) return;
+    const trimmedUrl = imageUrl?.trim();
+    if (trimmedUrl) {
+      this.widgetEl.style.backgroundImage = `url("${trimmedUrl}")`;
+      this.widgetEl.style.backgroundSize = 'cover';
+      this.widgetEl.style.backgroundPosition = 'center';
+      this.widgetEl.style.backgroundRepeat = 'no-repeat';
+      this.widgetEl.classList.add('has-background-image');
+    } else {
+      this.widgetEl.style.backgroundImage = '';
+      this.widgetEl.style.backgroundSize = '';
+      this.widgetEl.style.backgroundPosition = '';
+      this.widgetEl.style.backgroundRepeat = '';
+      this.widgetEl.classList.remove('has-background-image');
+    }
+  }
+
+  updateDisplay(state: { remainingTime: number; isRunning: boolean; currentPomodoroSet: 'work' | 'shortBreak' | 'longBreak'; pomodorosCompletedInCycle: number; settings: PomodoroSettings; }) {
+    if (!this.widgetEl) return;
+    const prev = this._prevDisplay;
+    const timeStr = this.formatTime(state.remainingTime);
+    if (prev.timeStr !== timeStr) {
+      this.timeDisplayEl.textContent = timeStr;
+      prev.timeStr = timeStr;
+    }
+    if (prev.isRunning !== state.isRunning) {
+      setIcon(this.startPauseButton, state.isRunning ? 'pause' : 'play');
+      this.startPauseButton.setAttribute('aria-label', state.isRunning ? '一時停止' : '開始');
+      prev.isRunning = state.isRunning;
+    }
+    if (!prev.resetIconSet) {
+      setIcon(this.resetButton, 'rotate-ccw');
+      this.resetButton.setAttribute('aria-label', 'リセット');
+      setIcon(this.nextButton, 'skip-forward');
+      this.nextButton.setAttribute('aria-label', '次のセッションへ');
+      prev.resetIconSet = true;
+    }
+    let statusText = '';
+    switch (state.currentPomodoroSet) {
+      case 'work':
+        statusText = `作業中 (${state.settings.workMinutes}分)`;
+        break;
+      case 'shortBreak':
+        statusText = `短い休憩 (${state.settings.shortBreakMinutes}分)`;
+        break;
+      case 'longBreak':
+        statusText = `長い休憩 (${state.settings.longBreakMinutes}分)`;
+        break;
+    }
+    if (prev.statusText !== statusText) {
+      this.statusDisplayEl.textContent = statusText;
+      prev.statusText = statusText;
+    }
+    const cycleText = `現在のサイクル: ${state.pomodorosCompletedInCycle} / ${state.settings.pomodorosUntilLongBreak}`;
+    if (prev.cycleText !== cycleText) {
+      this.cycleDisplayEl.textContent = cycleText;
+      prev.cycleText = cycleText;
+    }
+  }
+
+  private formatTime(totalSeconds: number): string {
+    const m = Math.floor(totalSeconds / 60);
+    const s = totalSeconds % 60;
+    return `${pad2(m)}:${pad2(s)}`;
+  }
+}
+
+export default PomodoroView;


### PR DESCRIPTION
## Summary
- split sound player, session logger and view logic into separate modules
- expose helper classes PomodoroSoundPlayer, PomodoroSessionLogger and PomodoroView
- adjust `PomodoroWidget` to use the new components
- update widget tests for new structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68558c96526483209e6709b2d0a18d15