### PR TITLE
Refactor markdown rendering helper

### DIFF
--- a/__tests__/utils/renderMarkdownBatch.test.ts
+++ b/__tests__/utils/renderMarkdownBatch.test.ts
@@ -12,7 +12,7 @@ jest.mock('obsidian', () => {
 }, { virtual: true });
 
 import { Component } from 'obsidian';
-const { renderMarkdownBatch } = require('../../src/utils/renderMarkdownBatch.ts');
+import { renderMarkdownBatch } from '../../src/utils/renderMarkdownBatch';
 
 describe('renderMarkdownBatch', () => {
   beforeEach(() => {

--- a/__tests__/utils/renderMarkdownBatchWithCache.test.ts
+++ b/__tests__/utils/renderMarkdownBatchWithCache.test.ts
@@ -15,7 +15,7 @@ jest.mock('obsidian', () => {
 import { Component } from 'obsidian';
 
 let MarkdownRenderer: { renderMarkdown: jest.Mock };
-const { renderMarkdownBatchWithCache } = require('../../src/utils/renderMarkdownBatch.ts');
+import { renderMarkdownBatchWithCache } from '../../src/utils/renderMarkdownBatch';
 
 describe('renderMarkdownBatchWithCache', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- add `renderOffscreenMarkdown` utility
- refactor existing rendering functions to use it
- switch tests to ES module imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68558c98a1e88320bc5cd119f93e7e65