### PR TITLE
Add missing utils tests

### DIFF
--- a/__tests__/utils/renderMarkdownBatchSegmentedWithCache.test.ts
+++ b/__tests__/utils/renderMarkdownBatchSegmentedWithCache.test.ts
@@ -1,0 +1,59 @@
+jest.mock('obsidian', () => {
+  return {
+    MarkdownRenderer: {
+      renderMarkdown: jest.fn((md: string, el: HTMLElement) => {
+        el.innerHTML = `<p>${md}</p>`;
+        return Promise.resolve();
+      }),
+    },
+    Component: class {},
+    TFile: class {},
+  };
+}, { virtual: true });
+
+import { Component } from 'obsidian';
+import { MessageChannel as NodeMessageChannel } from 'worker_threads';
+
+let MarkdownRenderer: { renderMarkdown: jest.Mock };
+let renderMarkdownBatchSegmentedWithCache: any;
+
+beforeAll(() => {
+  if (typeof (global as any).MessageChannel === 'undefined') {
+    (global as any).MessageChannel = NodeMessageChannel;
+  }
+});
+
+describe('renderMarkdownBatchSegmentedWithCache', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    MarkdownRenderer = require('obsidian').MarkdownRenderer as any;
+    renderMarkdownBatchSegmentedWithCache = require('../../src/utils/renderMarkdownBatch').renderMarkdownBatchSegmentedWithCache;
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  test('renders segments and caches them', async () => {
+    const container1 = document.createElement('div');
+    await renderMarkdownBatchSegmentedWithCache('a\n\nb', container1, '', new Component());
+    await new Promise(r => setTimeout(r, 10));
+    expect(container1.innerHTML).toBe('<p>a</p><p>b</p>');
+    expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledTimes(2);
+
+    const container2 = document.createElement('div');
+    await renderMarkdownBatchSegmentedWithCache('a\n\nb', container2, '', new Component());
+    await new Promise(r => setTimeout(r, 10));
+    expect(container2.innerHTML).toBe('<p>a</p><p>b</p>');
+    expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledTimes(2);
+  });
+
+  test('evicts oldest segment when cache exceeds limit', async () => {
+    const segments = Array.from({ length: 101 }, (_, i) => `seg${i}`).join('\n\n');
+    await renderMarkdownBatchSegmentedWithCache(segments, document.createElement('div'), '', new Component());
+    await new Promise(r => setTimeout(r, 10));
+    expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledTimes(101);
+
+    await renderMarkdownBatchSegmentedWithCache('seg0', document.createElement('div'), '', new Component());
+    await new Promise(r => setTimeout(r, 10));
+    expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledTimes(102);
+  });
+});

--- a/__tests__/utils/uiHelpers.test.ts
+++ b/__tests__/utils/uiHelpers.test.ts
@@ -1,0 +1,36 @@
+import { createAccordion } from '../../src/utils/uiHelpers';
+
+beforeAll(() => {
+  if (!(HTMLElement.prototype as any).appendText) {
+    (HTMLElement.prototype as any).appendText = function(text: string) {
+      this.appendChild(document.createTextNode(text));
+    };
+  }
+});
+
+describe('createAccordion', () => {
+  test('creates accordion and toggles body visibility', () => {
+    const container = document.createElement('div');
+    const { acc, header, body } = createAccordion(container, 'Title', false);
+
+    expect(container.contains(acc)).toBe(true);
+    expect(header.textContent).toContain('Title');
+    expect(body.style.display).toBe('none');
+
+    header.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(acc.classList.contains('wb-accordion-open')).toBe(true);
+    expect(body.style.display).toBe('');
+
+    header.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(acc.classList.contains('wb-accordion-open')).toBe(false);
+    expect(body.style.display).toBe('none');
+  });
+
+  test('defaultOpen expands initially', () => {
+    const container = document.createElement('div');
+    const { acc, header, body } = createAccordion(container, 'Title', true);
+    expect(acc.classList.contains('wb-accordion-open')).toBe(true);
+    expect(header.classList.contains('wb-accordion-open')).toBe(true);
+    expect(body.style.display).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for UI helper createAccordion
- add tests for segmented markdown rendering with cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68575b8bc1e883209193d7ae4e814b2d