### PR TITLE
Add missing utils tests

### DIFF
--- a/__tests__/utils/renderMarkdownBatchSegmentedWithCache.test.ts
+++ b/__tests__/utils/renderMarkdownBatchSegmentedWithCache.test.ts
@@ -1,0 +1,74 @@
+// Provide a virtual mock for the Obsidian API used in the utils
+jest.mock('obsidian', () => {
+  return {
+    MarkdownRenderer: {
+      renderMarkdown: jest.fn((md: string, el: HTMLElement) => {
+        el.innerHTML = `<p>${md}</p>`;
+        return Promise.resolve();
+      }),
+    },
+    Component: class {},
+    TFile: class {},
+  };
+}, { virtual: true });
+
+import { Component } from 'obsidian';
+
+if (typeof (global as any).MessageChannel === 'undefined') {
+  const { MessageChannel } = require('worker_threads');
+  (global as any).MessageChannel = MessageChannel;
+}
+
+let MarkdownRenderer: { renderMarkdown: jest.Mock };
+import { renderMarkdownBatchSegmentedWithCache } from '../../src/utils/renderMarkdownBatch';
+
+const flush = () => new Promise(res => setTimeout(res, 0));
+
+describe('renderMarkdownBatchSegmentedWithCache', () => {
+  beforeEach(() => {
+    MarkdownRenderer = require('obsidian').MarkdownRenderer as any;
+    jest.clearAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  test('renders segments sequentially', async () => {
+    const container = document.createElement('div');
+    await renderMarkdownBatchSegmentedWithCache('a\n\nb', container, '', new Component());
+    await flush();
+    await flush();
+    expect(container.innerHTML).toBe('<p>a</p><p>b</p>');
+    expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledTimes(2);
+  });
+
+  test('reuses cached segments', async () => {
+    const container1 = document.createElement('div');
+    await renderMarkdownBatchSegmentedWithCache('x\n\ny', container1, '', new Component());
+    await flush();
+    await flush();
+    expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledTimes(2);
+
+    jest.clearAllMocks();
+    const container2 = document.createElement('div');
+    await renderMarkdownBatchSegmentedWithCache('x\n\ny', container2, '', new Component());
+    await flush();
+    await flush();
+    expect(MarkdownRenderer.renderMarkdown).not.toHaveBeenCalled();
+    expect(container2.innerHTML).toBe(container1.innerHTML);
+  });
+
+  test('respects cache size limit', async () => {
+    for (let i = 0; i < 100; i++) {
+      await renderMarkdownBatchSegmentedWithCache(`seg${i}`, document.createElement('div'), '', new Component());
+      await flush();
+    }
+    expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledTimes(100);
+
+    await renderMarkdownBatchSegmentedWithCache('extra', document.createElement('div'), '', new Component());
+    await flush();
+    expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledTimes(101);
+
+    await renderMarkdownBatchSegmentedWithCache('seg0', document.createElement('div'), '', new Component());
+    await flush();
+    expect(MarkdownRenderer.renderMarkdown).toHaveBeenCalledTimes(102);
+  });
+});

--- a/__tests__/utils/uiHelpers.test.ts
+++ b/__tests__/utils/uiHelpers.test.ts
@@ -1,0 +1,50 @@
+import { createAccordion } from '../../src/utils/uiHelpers';
+
+if (!HTMLElement.prototype.appendText) {
+  HTMLElement.prototype.appendText = function (text: string) {
+    this.appendChild(document.createTextNode(text));
+  };
+}
+
+describe('createAccordion', () => {
+  let container: HTMLElement;
+  beforeEach(() => {
+    container = document.createElement('div');
+  });
+
+  test('creates closed accordion by default', () => {
+    const { acc, header, body } = createAccordion(container, 'Title');
+    expect(container.contains(acc)).toBe(true);
+    expect(acc.classList.contains('wb-accordion')).toBe(true);
+    expect(acc.classList.contains('wb-accordion-open')).toBe(false);
+    expect(header.classList.contains('wb-accordion-header')).toBe(true);
+    expect(body.style.display).toBe('none');
+  });
+
+  test('creates open accordion when defaultOpen true', () => {
+    const { acc, header, body } = createAccordion(container, 'Open', true);
+    expect(acc.classList.contains('wb-accordion-open')).toBe(true);
+    expect(header.classList.contains('wb-accordion-open')).toBe(true);
+    expect(body.style.display).toBe('');
+  });
+
+  test('toggles open/close on header click', () => {
+    const { acc, header, body } = createAccordion(container, 'Toggle');
+    header.click();
+    expect(acc.classList.contains('wb-accordion-open')).toBe(true);
+    expect(header.classList.contains('wb-accordion-open')).toBe(true);
+    expect(body.style.display).toBe('');
+    header.click();
+    expect(acc.classList.contains('wb-accordion-open')).toBe(false);
+    expect(header.classList.contains('wb-accordion-open')).toBe(false);
+    expect(body.style.display).toBe('none');
+  });
+
+  test('ignores click on header child elements', () => {
+    const { acc, header, body } = createAccordion(container, 'Child');
+    const icon = header.querySelector('.wb-accordion-icon') as HTMLElement;
+    icon.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(acc.classList.contains('wb-accordion-open')).toBe(false);
+    expect(body.style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for renderMarkdownBatchSegmentedWithCache
- add tests for uiHelpers' createAccordion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68575b8bc1e883209193d7ae4e814b2d