### PR TITLE
Add more widget tests

### DIFF
--- a/__tests__/widgets/scheduleUtils.test.ts
+++ b/__tests__/widgets/scheduleUtils.test.ts
@@ -7,4 +7,37 @@ describe('computeNextTime', () => {
     const expected = new Date('2024-05-13T09:00:00Z').getTime();
     expect(next).toBe(expected);
   });
+
+  it('returns same day when time is in the future', () => {
+    const now = new Date('2024-05-06T07:00:00Z'); // Monday
+    const next = computeNextTime({ hour: 9, minute: 0, daysOfWeek: [1] }, now);
+    const expected = new Date('2024-05-06T09:00:00Z').getTime();
+    expect(next).toBe(expected);
+  });
+
+  it('handles start and end dates', () => {
+    const now = new Date('2024-05-06T10:00:00Z'); // Monday
+    const next = computeNextTime(
+      { hour: 9, minute: 0, daysOfWeek: [5], startDate: '2024-05-10', endDate: '2024-05-11' },
+      now
+    );
+    const expected = new Date('2024-05-10T09:00:00Z').getTime();
+    expect(next).toBe(expected);
+  });
+
+  it('returns null when beyond endDate', () => {
+    const now = new Date('2024-05-06T10:00:00Z');
+    const next = computeNextTime(
+      { hour: 9, minute: 0, daysOfWeek: [1], endDate: '2024-05-07' },
+      now
+    );
+    expect(next).toBeNull();
+  });
+
+  it('picks earliest day from multiple daysOfWeek', () => {
+    const now = new Date('2024-05-06T10:00:00Z'); // Monday
+    const next = computeNextTime({ hour: 9, minute: 0, daysOfWeek: [2, 4] }, now);
+    const expected = new Date('2024-05-07T09:00:00Z').getTime();
+    expect(next).toBe(expected);
+  });
 });

--- a/__tests__/widgets/timerStopwatchWidget.test.ts
+++ b/__tests__/widgets/timerStopwatchWidget.test.ts
@@ -166,4 +166,68 @@ describe('TimerStopwatchWidget', () => {
     // 仮に順序を保存する関数があればここで呼ぶ（例: saveWidgetOrder）
     // expect(saveWidgetOrder()).toEqual(['w2', 'w1']);
   });
-}); 
+
+  it('formatTimeが正しくmm:ss形式を返す', () => {
+    const widget = new TimerStopwatchWidget();
+    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    expect((widget as any).formatTime(0)).toBe('00:00');
+    expect((widget as any).formatTime(70)).toBe('01:10');
+    expect((widget as any).formatTime(3599)).toBe('59:59');
+  });
+
+  describe('openBoardIfClosed', () => {
+    it('全て閉じている場合はボードを開く', () => {
+      const plugin = {
+        settings: {
+          language: 'ja',
+          boards: [{ id: 'b1', widgets: [{ id: dummyConfig.id }] }],
+        },
+        boardManager: {
+          widgetBoardModals: new Map([['b1', { isOpen: false }]]),
+        },
+        openWidgetBoardById: jest.fn(),
+        openBoardPicker: jest.fn(),
+      } as any;
+      const widget = new TimerStopwatchWidget();
+      widget.create(dummyConfig, dummyApp, plugin);
+      (widget as any).openBoardIfClosed();
+      expect(plugin.openWidgetBoardById).toHaveBeenCalledWith('b1');
+      expect(plugin.openBoardPicker).not.toHaveBeenCalled();
+    });
+
+    it('ボードが見つからない場合はピッカーを開く', () => {
+      const plugin = {
+        settings: { language: 'ja', boards: [] },
+        boardManager: {
+          widgetBoardModals: new Map([['x', { isOpen: false }]]),
+        },
+        openWidgetBoardById: jest.fn(),
+        openBoardPicker: jest.fn(),
+      } as any;
+      const widget = new TimerStopwatchWidget();
+      widget.create(dummyConfig, dummyApp, plugin);
+      (widget as any).openBoardIfClosed();
+      expect(plugin.openWidgetBoardById).not.toHaveBeenCalled();
+      expect(plugin.openBoardPicker).toHaveBeenCalled();
+    });
+
+    it('モーダルが開いている場合は何もしない', () => {
+      const plugin = {
+        settings: {
+          language: 'ja',
+          boards: [{ id: 'b1', widgets: [{ id: dummyConfig.id }] }],
+        },
+        boardManager: {
+          widgetBoardModals: new Map([['b1', { isOpen: true }]]),
+        },
+        openWidgetBoardById: jest.fn(),
+        openBoardPicker: jest.fn(),
+      } as any;
+      const widget = new TimerStopwatchWidget();
+      widget.create(dummyConfig, dummyApp, plugin);
+      (widget as any).openBoardIfClosed();
+      expect(plugin.openWidgetBoardById).not.toHaveBeenCalled();
+      expect(plugin.openBoardPicker).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extend schedule utility tests
- verify TimerStopwatchWidget formatting
- test board opening logic in TimerStopwatchWidget

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68575bab10388320a43cc54d5333deb8