### PR TITLE
Replace getFiles scan with direct lookup

### DIFF
--- a/__tests__/widgets/tweetWidget.test.ts
+++ b/__tests__/widgets/tweetWidget.test.ts
@@ -12,6 +12,7 @@ describe('TweetWidget', () => {
     vault: {
       adapter: { exists: jest.fn(), mkdir: jest.fn(), read: jest.fn(), write: jest.fn() },
       getFiles: jest.fn(() => []),
+      getFileByPath: jest.fn(() => null),
     },
     workspace: { getActiveFile: jest.fn(() => ({ path: 'active.md' })) },
   } as any;

--- a/src/widgets/tweetWidget/tweetWidget.ts
+++ b/src/widgets/tweetWidget/tweetWidget.ts
@@ -529,7 +529,7 @@ export class TweetWidget implements WidgetImplementation {
             const bin = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
             await this.app.vault.createBinary(vaultPath, bin);
             // Vaultファイルを取得し、getResourcePathでURLを取得
-            const vaultFile = this.app.vault.getFiles().find(f => f.path === vaultPath);
+            const vaultFile = this.app.vault.getFileByPath(vaultPath);
             let url = '';
             if (vaultFile) {
                 url = this.app.vault.getResourcePath(vaultFile);

--- a/src/widgets/tweetWidget/tweetWidgetUI.ts
+++ b/src/widgets/tweetWidget/tweetWidgetUI.ts
@@ -841,9 +841,8 @@ export class TweetWidgetUI {
             }
         }
         // Vault内画像のパスをgetResourcePathでURLに変換
-        const vaultFiles = this.app.vault.getFiles();
-        // デバッグモード判定（なければfalse）
         const debugLogging = this.widget?.plugin?.settings?.debugLogging === true;
+        const vaultFiles = debugLogging ? this.app.vault.getFiles() : [];
         replacedText = replacedText.replace(/!\[\[(.+?)\]\]/g, (match, p1) => {
             let fileName = p1;
             try {
@@ -853,7 +852,10 @@ export class TweetWidgetUI {
             if (debugLogging) {
                 debugLog(this.widget?.plugin, '[tweetWidgetUI] 画像置換: p1=', p1, 'fileName=', fileName, 'vaultFiles=', vaultFiles.map(f => ({name: f.name, path: f.path})));
             }
-            const f = vaultFiles.find(f => f.name === fileName || f.path === fileName || f.path === p1 || f.name === p1);
+            let f = this.app.vault.getFileByPath(p1) || this.app.vault.getFileByPath(fileName);
+            if (!f) {
+                f = vaultFiles.find(v => v.name === fileName || v.name === p1) || null;
+            }
             if (f) {
                 if (debugLogging) debugLog(this.widget?.plugin, '[tweetWidgetUI] マッチしたファイル:', f);
                 const url = this.app.vault.getResourcePath(f);
@@ -872,7 +874,10 @@ export class TweetWidgetUI {
             if (debugLogging) {
                 debugLog(this.widget?.plugin, '[tweetWidgetUI] 画像置換 (md): p1=', p1, 'fileName=', fileName, 'vaultFiles=', vaultFiles.map(f => ({name: f.name, path: f.path})));
             }
-            const f = vaultFiles.find(f => f.name === fileName || f.path === fileName || f.path === p1 || f.name === p1);
+            let f = this.app.vault.getFileByPath(p1) || this.app.vault.getFileByPath(fileName);
+            if (!f) {
+                f = vaultFiles.find(v => v.name === fileName || v.name === p1) || null;
+            }
             if (f) {
                 if (debugLogging) debugLog(this.widget?.plugin, '[tweetWidgetUI] マッチしたファイル (md):', f);
                 const url = this.app.vault.getResourcePath(f);


### PR DESCRIPTION
## Summary
- use `app.vault.getFileByPath` instead of scanning `getFiles()` when the full path is known
- update TweetWidget UI lookups to try `getFileByPath` before falling back
- extend tweet widget tests with mocked `getFileByPath`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68576cbb22fc8320929c184c55d045d2