### PR TITLE
Add CSS utility classes

### DIFF
--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -171,8 +171,7 @@ export class WidgetBoardSettingTab extends PluginSettingTab {
                 slider.setLimits(0, 1, 0.01)
                     .setValue(this.plugin.settings.pomodoroNotificationVolume ?? 0.2);
                 const valueLabel = document.createElement('span');
-                valueLabel.style.marginLeft = '12px';
-                valueLabel.style.fontWeight = 'bold';
+                valueLabel.classList.add('value-label');
                 valueLabel.textContent = String((this.plugin.settings.pomodoroNotificationVolume ?? 0.2).toFixed(2));
                 slider.sliderEl.parentElement?.appendChild(valueLabel);
                 slider.onChange(async (value) => {
@@ -254,8 +253,7 @@ export class WidgetBoardSettingTab extends PluginSettingTab {
                 slider.setLimits(0, 1, 0.01)
                     .setValue(this.plugin.settings.timerStopwatchNotificationVolume ?? 0.5);
                 const valueLabel = document.createElement('span');
-                valueLabel.style.marginLeft = '12px';
-                valueLabel.style.fontWeight = 'bold';
+                valueLabel.classList.add('value-label');
                 valueLabel.textContent = String((this.plugin.settings.timerStopwatchNotificationVolume ?? 0.5).toFixed(2));
                 slider.sliderEl.parentElement?.appendChild(valueLabel);
                 slider.onChange(async (value) => {
@@ -282,7 +280,7 @@ export class WidgetBoardSettingTab extends PluginSettingTab {
                 const toggleBtn = document.createElement('button');
                 toggleBtn.type = 'button';
                 toggleBtn.textContent = t(lang, 'show');
-                toggleBtn.style.marginLeft = '8px';
+                toggleBtn.classList.add('toggle-button');
                 toggleBtn.onclick = () => {
                     if (text.inputEl.type === 'password') {
                         text.inputEl.type = 'text';

--- a/src/widgets/reflectionWidget/reflectionWidgetUI.ts
+++ b/src/widgets/reflectionWidget/reflectionWidgetUI.ts
@@ -260,9 +260,9 @@ export class ReflectionWidgetUI {
             const settings = this.config.settings as ReflectionWidgetSettings;
             if (settings.aiSummaryManualEnabled) {
                 const manualBtnContainer = document.createElement('div');
-                manualBtnContainer.style.textAlign = 'center';
-                manualBtnContainer.style.marginTop = '16px';
+                manualBtnContainer.classList.add('manual-button-container');
                 this.manualBtnEl = document.createElement('button');
+                this.manualBtnEl.classList.add('manual-button');
                 this.manualBtnEl.innerText = t(this.plugin.settings.language || 'ja', 'generateSummary');
                 const trigger = () => this.runSummary(true);
                 this.manualBtnEl.onclick = trigger;
@@ -549,8 +549,8 @@ export class ReflectionWidgetUI {
         // 手動発火ボタン（初回のみ生成）
         if (manualEnabled && this.aiSummarySectionEl && !this.manualBtnEl) {
             this.manualBtnEl = document.createElement('button');
+            this.manualBtnEl.classList.add('manual-button');
             this.manualBtnEl.innerText = t(this.plugin.settings.language || 'ja', 'generateSummary');
-            this.manualBtnEl.style.margin = '10px 0 0 0';
             this.manualBtnEl.onclick = async () => {
                 this.manualBtnEl!.disabled = true;
                 this.manualBtnEl!.innerText = t(this.plugin.settings.language || 'ja', 'generating');

--- a/styles.css
+++ b/styles.css
@@ -2460,3 +2460,22 @@ body.wb-modal-left-outer-open .workspace {
 .reflection-manual-btn {
     margin: 10px 0 0 0;
 }
+
+/* Generic utility classes */
+.value-label {
+    margin-left: 12px;
+    font-weight: bold;
+}
+
+.manual-button-container {
+    text-align: center;
+    margin-top: 16px;
+}
+
+.manual-button {
+    margin: 10px 0 0 0;
+}
+
+.toggle-button {
+    margin-left: 8px;
+}


### PR DESCRIPTION
## Summary
- add generic CSS classes for widget styling
- use the new classes in Settings and Reflection widget

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685774226ef883208a339990387cf913