### PR TITLE
Refactor vault JSON handling

### DIFF
--- a/__tests__/widgets/aiPrompt.test.ts
+++ b/__tests__/widgets/aiPrompt.test.ts
@@ -131,7 +131,17 @@ describe('AI prompt integration', () => {
       ),
       write: jest.fn(),
     };
-    const app = { vault: { adapter, getAbstractFileByPath: jest.fn((p: string) => p === 'tweets.json' ? file : null), read: adapter.read, create: jest.fn(), modify: jest.fn(), createFolder: jest.fn() } } as unknown as App;
+    const app = {
+      vault: {
+        adapter,
+        getFileByPath: jest.fn((p: string) => (p === 'tweets.json' ? file : null)),
+        getAbstractFileByPath: jest.fn((p: string) => (p === 'tweets.json' ? file : null)),
+        read: adapter.read,
+        create: jest.fn(),
+        process: jest.fn(),
+        createFolder: jest.fn(),
+      },
+    } as unknown as App;
     const plugin = {
       settings: {
         weekStartDay: 1,
@@ -168,17 +178,24 @@ describe('AI prompt integration', () => {
     const file = new TFile();
     const adapter = {
       exists: jest.fn().mockResolvedValue(true),
+      read: jest.fn(),
+      write: jest.fn(),
+    };
+    const vault = {
+      adapter,
+      getFileByPath: jest.fn((p: string) => (p === 'data.json' ? file : null)),
       read: jest.fn().mockResolvedValue(
         JSON.stringify({ reflectionSummaries: { today: { date: 'd', summary: 's', html: '<p>s</p>', postCount: 1 } } })
       ),
-      write: jest.fn(),
+      process: jest.fn(),
+      create: jest.fn(),
     };
-    const app = { vault: { adapter, getAbstractFileByPath: jest.fn((p: string) => p === 'data.json' ? file : null), read: adapter.read, create: jest.fn(), modify: jest.fn(), createFolder: jest.fn() } } as unknown as App;
+    const app = { vault } as unknown as App;
 
     const res1 = await loadReflectionSummaryShared('today', 'd', app);
-    expect(adapter.read).toHaveBeenCalledTimes(1);
+    expect(vault.read).toHaveBeenCalledTimes(1);
     const res2 = await loadReflectionSummaryShared('today', 'd', app);
-    expect(adapter.read).toHaveBeenCalledTimes(1);
+    expect(vault.read).toHaveBeenCalledTimes(1);
     expect(res2).toEqual(res1);
   });
 });

--- a/__tests__/widgets/reflectionWidget.test.ts
+++ b/__tests__/widgets/reflectionWidget.test.ts
@@ -22,10 +22,10 @@ describe('ReflectionWidget 詳細テスト', () => {
           read: jest.fn().mockResolvedValue('{"posts": [], "scheduledPosts": []}'),
           write: jest.fn(),
         },
-        getAbstractFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
+        getFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
         read: jest.fn(),
         create: jest.fn(),
-        modify: jest.fn(),
+        process: jest.fn(),
         createFolder: jest.fn(),
       },
     };
@@ -91,10 +91,10 @@ describe('ReflectionWidget 設定値テスト', () => {
     dummyApp = {
       vault: {
         adapter: { exists: jest.fn().mockResolvedValue(true), read: jest.fn().mockResolvedValue('{}'), write: jest.fn() },
-        getAbstractFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
+        getFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
         read: jest.fn(),
         create: jest.fn(),
-        modify: jest.fn(),
+        process: jest.fn(),
         createFolder: jest.fn(),
       }
     };
@@ -149,10 +149,10 @@ describe('ReflectionWidget プリロードバンドルテスト', () => {
           read: jest.fn().mockResolvedValue('{"posts": [], "scheduledPosts": []}'),
           write: jest.fn(),
         },
-        getAbstractFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
+        getFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
         read: jest.fn(),
         create: jest.fn(),
-        modify: jest.fn(),
+        process: jest.fn(),
         createFolder: jest.fn(),
       },
     };
@@ -198,10 +198,10 @@ describe('ReflectionWidget UI統合テスト', () => {
           read: jest.fn().mockResolvedValue('{"posts": [], "scheduledPosts": []}'),
           write: jest.fn()
         },
-        getAbstractFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
+        getFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
         read: jest.fn(),
         create: jest.fn(),
-        modify: jest.fn(),
+        process: jest.fn(),
         createFolder: jest.fn()
       }
     };
@@ -281,10 +281,10 @@ describe('ReflectionWidget データ永続化テスト', () => {
           read: jest.fn().mockResolvedValue('{"reflectionSummaries": {}}'),
           write: jest.fn().mockResolvedValue(undefined)
         },
-        getAbstractFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
+        getFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
         read: jest.fn(),
         create: jest.fn(),
-        modify: jest.fn(),
+        process: jest.fn(),
         createFolder: jest.fn()
       }
     };
@@ -299,10 +299,10 @@ describe('ReflectionWidget データ永続化テスト', () => {
           read: jest.fn().mockResolvedValue('{"reflectionSummaries": {}}'),
           write: jest.fn().mockResolvedValue(undefined)
         },
-        getAbstractFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
+        getFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
         read: jest.fn(),
         create: jest.fn(),
-        modify: jest.fn(),
+        process: jest.fn(),
         createFolder: jest.fn()
       }
     } as unknown as App;
@@ -317,7 +317,7 @@ describe('ReflectionWidget データ永続化テスト', () => {
       (widget['ui'] as any).app = mockApp;
 
       await widget['ui']['runSummary'](true);
-      expect(mockApp.vault.adapter.write).toHaveBeenCalled();
+      expect(mockApp.vault.process).toHaveBeenCalled();
     }
   });
 
@@ -329,10 +329,10 @@ describe('ReflectionWidget データ永続化テスト', () => {
           read: jest.fn().mockRejectedValue(new Error('File not found')),
           write: jest.fn().mockResolvedValue(undefined)
         },
-        getAbstractFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
+        getFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
         read: jest.fn(),
         create: jest.fn(),
-        modify: jest.fn(),
+        process: jest.fn(),
         createFolder: jest.fn()
       }
     } as unknown as App;
@@ -361,10 +361,10 @@ describe('ReflectionWidget パフォーマンステスト', () => {
                 read: jest.fn().mockResolvedValue('{}'),
                 write: jest.fn(),
             },
-            getAbstractFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
+            getFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
             read: jest.fn(),
             create: jest.fn(),
-            modify: jest.fn(),
+            process: jest.fn(),
             createFolder: jest.fn(),
         },
     };
@@ -435,10 +435,10 @@ describe('ReflectionWidget エラーハンドリングテスト', () => {
           read: jest.fn().mockResolvedValue('{"posts": [], "scheduledPosts": []}'),
           write: jest.fn()
         },
-        getAbstractFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
+        getFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
         read: jest.fn(),
         create: jest.fn(),
-        modify: jest.fn(),
+        process: jest.fn(),
         createFolder: jest.fn()
       }
     };
@@ -527,6 +527,11 @@ describe('ReflectionWidget アクセシビリティテスト', () => {
           read: jest.fn().mockResolvedValue('{"posts": [], "scheduledPosts": []}'),
           write: jest.fn(),
         },
+        getFileByPath: jest.fn(() => new (require('obsidian').TFile)()),
+        read: jest.fn(),
+        create: jest.fn(),
+        process: jest.fn(),
+        createFolder: jest.fn(),
       },
     };
     dummyPlugin = { settings: { weekStartDay: 1 } };

--- a/src/prewarm.ts
+++ b/src/prewarm.ts
@@ -79,11 +79,14 @@ export class PrewarmManager {
 
             async function loadReflectionSummary(type: 'today' | 'week', dateKey: string, app: App): Promise<string | null> {
                 const path = 'data.json';
+                const file = app.vault.getFileByPath(path);
                 try {
-                    const raw = await app.vault.adapter.read(path);
-                    const data = JSON.parse(raw);
-                    if (data.reflectionSummaries && data.reflectionSummaries[type]?.date === dateKey) {
-                        return data.reflectionSummaries[type].summary;
+                    if (file) {
+                        const raw = await app.vault.read(file);
+                        const data = JSON.parse(raw);
+                        if (data.reflectionSummaries && data.reflectionSummaries[type]?.date === dateKey) {
+                            return data.reflectionSummaries[type].summary;
+                        }
                     }
                 } catch {
                     // ignore error if file doesn't exist


### PR DESCRIPTION
## Summary
- update reflection summary functions to use `vault.getFileByPath` and `vault.read/process`
- adjust prewarm logic for new file API
- update related tests for new Vault API use

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857742551fc8320adac47d44d3b8e98