### PR TITLE
Remove heading from settings tab

### DIFF
--- a/src/settingsTab.ts
+++ b/src/settingsTab.ts
@@ -43,7 +43,7 @@ export class WidgetBoardSettingTab extends PluginSettingTab {
         containerEl.empty();
         const lang: Language = this.plugin.settings.language || 'ja';
 
-        new Setting(containerEl).setName(t(lang, 'settingTabHeading')).setHeading();
+        
         // --- ベースフォルダ入力欄 ---
         const baseFolderSetting = new Setting(containerEl)
             .setName(t(lang, 'baseFolderGlobal'))


### PR DESCRIPTION
## Summary
- remove the heading at the top of the settings tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857788d7b348320987295803860127f