### PR TITLE
Add board button style class

### DIFF
--- a/src/settings/boardGroupSettings.ts
+++ b/src/settings/boardGroupSettings.ts
@@ -752,17 +752,8 @@ export class BoardGroupEditModal extends Modal {
             this.plugin.settings.boards.forEach(b => {
                 const isSelected = boardIds.has(b.id);
                 const btn = boardButtonsEl.createEl('button', {
-                    cls: isSelected ? 'selected is-active' : '',
+                    cls: `wb-board-btn mod-cta${isSelected ? ' is-active' : ''}`,
                 });
-                btn.classList.add('mod-cta');
-                btn.style.minWidth = '64px';
-                btn.style.padding = '6px 16px';
-                btn.style.borderRadius = '6px';
-                btn.style.border = 'none';
-                btn.style.cursor = 'pointer';
-                btn.style.fontWeight = isSelected ? 'bold' : '';
-                btn.style.background = isSelected ? 'var(--interactive-accent)' : 'var(--background-modifier-box)';
-                btn.style.color = isSelected ? 'var(--text-on-accent)' : 'var(--text-normal)';
                 btn.setText(b.name);
                 btn.onclick = () => {
                     if (isSelected) {

--- a/styles.css
+++ b/styles.css
@@ -2479,3 +2479,20 @@ body.wb-modal-left-outer-open .workspace {
 .toggle-button {
     margin-left: 8px;
 }
+
+/* Board selection button */
+.wb-board-btn {
+    min-width: 64px;
+    padding: 6px 16px;
+    border-radius: 6px;
+    border: none;
+    cursor: pointer;
+    background: var(--background-modifier-box);
+    color: var(--text-normal);
+}
+
+.wb-board-btn.is-active {
+    background: var(--interactive-accent);
+    color: var(--text-on-accent);
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add `.wb-board-btn` reusable CSS rule
- use the new class for group edit board selection buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857788c60fc8320ac7d36a59107bbb3