### PR TITLE
Refactor async patterns

### DIFF
--- a/__tests__/widgets/tweetWidget.test.ts
+++ b/__tests__/widgets/tweetWidget.test.ts
@@ -29,33 +29,32 @@ describe('TweetWidget', () => {
     getTweetPostCounts: jest.fn(() => [])
   } as any;
 
-  it('createメソッドでHTMLElementを返す', () => {
+  it('createメソッドでHTMLElementを返す', async () => {
     const widget = new TweetWidget();
-    const el = widget.create(dummyConfig, dummyApp, dummyPlugin);
+    const el = await widget.create(dummyConfig, dummyApp, dummyPlugin);
     expect(el).toBeInstanceOf(HTMLElement);
   });
 
   it('switchTabでcurrentTabが切り替わる', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.switchTab('notification');
     expect(widget.currentTab).toBe('notification');
   });
 
-  it('setFilterでcurrentFilterが切り替わる', () => {
+  it('setFilterでcurrentFilterが切り替わる', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     // wait for async init
-    return Promise.resolve().then(() => new Promise(res => setTimeout(res, 0))).then(() => {
-      widget.setFilter('bookmark');
-      expect(widget.currentFilter).toBe('bookmark');
-    });
+    await new Promise(res => setTimeout(res, 0));
+    widget.setFilter('bookmark');
+    expect(widget.currentFilter).toBe('bookmark');
   });
 
   it('submitPostで投稿が追加される', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('テスト投稿');
     expect(widget.currentSettings.posts.length).toBeGreaterThan(0);
@@ -63,7 +62,7 @@ describe('TweetWidget', () => {
 
   it('submitReplyで返信が追加される', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitReply('返信テスト', 'parent-id');
     expect(widget.currentSettings.posts.length).toBeGreaterThan(0);
@@ -71,7 +70,7 @@ describe('TweetWidget', () => {
 
   it('toggleLikeでlikedが切り替わる', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('いいねテスト');
     const postId = widget.currentSettings.posts[0].id;
@@ -81,7 +80,7 @@ describe('TweetWidget', () => {
 
   it('存在しないIDのtoggleLikeで状態が変わらない', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('test');
     const before = widget.currentSettings.posts[0].liked;
@@ -89,16 +88,16 @@ describe('TweetWidget', () => {
     expect(widget.currentSettings.posts[0].liked).toBe(before);
   });
 
-  it('tweet-widgetクラスとタイトルが付与される', () => {
+  it('tweet-widgetクラスとタイトルが付与される', async () => {
     const widget = new TweetWidget();
-    const el = widget.create(dummyConfig, dummyApp, dummyPlugin);
+    const el = await widget.create(dummyConfig, dummyApp, dummyPlugin);
     expect(el.classList.contains('tweet-widget')).toBe(true);
     expect(el.textContent).toBe('Loading...');
   });
 
   it('タブ切替でcurrentTabが切り替わりUIが再描画される', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     const spy = jest.spyOn(widget['ui'], 'render');
     await widget.switchTab('notification');
@@ -108,7 +107,7 @@ describe('TweetWidget', () => {
 
   it('setFilterでcurrentFilterが切り替わりUIが再描画される', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     const spy = jest.spyOn(widget['ui'], 'render');
     widget.setFilter('bookmark');
@@ -118,7 +117,7 @@ describe('TweetWidget', () => {
 
   it('投稿編集でeditingPostIdやUIが正しく切り替わる', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('編集テスト');
     const post = widget.currentSettings.posts[0];
@@ -129,7 +128,7 @@ describe('TweetWidget', () => {
 
   it('投稿詳細表示でdetailPostIdが切り替わる', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('詳細テスト');
     const post = widget.currentSettings.posts[0];
@@ -139,7 +138,7 @@ describe('TweetWidget', () => {
 
   it('navigateToDetailでresetScrollが呼ばれる', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('scroll test');
     const post = widget.currentSettings.posts[0];
@@ -153,7 +152,7 @@ describe('TweetWidget', () => {
     const panel = document.createElement('div');
     panel.className = 'widget-board-panel-custom';
     document.body.appendChild(panel);
-    const el = widget.create(dummyConfig, dummyApp, dummyPlugin);
+    const el = await widget.create(dummyConfig, dummyApp, dummyPlugin);
     panel.appendChild(el);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('scroll test');
@@ -168,7 +167,7 @@ describe('TweetWidget', () => {
   it('ファイル添付でattachedFilesが更新される', async () => {
     dummyApp.vault.createBinary = jest.fn();
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     const file = new File(['test'], 'test.txt');
     await widget.attachFiles([file]);
@@ -177,7 +176,7 @@ describe('TweetWidget', () => {
 
   it('空投稿ではsubmitPostで投稿が追加されない', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     const before = widget.currentSettings.posts.length;
     await widget.submitPost('   ');
@@ -186,7 +185,7 @@ describe('TweetWidget', () => {
 
   it('toggleRetweetでretweetedが切り替わる', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('リツイートテスト');
     const postId = widget.currentSettings.posts[0].id;
@@ -196,7 +195,7 @@ describe('TweetWidget', () => {
 
   it('toggleBookmarkでbookmarkが切り替わる', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('ブックマークテスト');
     const postId = widget.currentSettings.posts[0].id;
@@ -206,7 +205,7 @@ describe('TweetWidget', () => {
 
   it('deletePostで投稿が削除される', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('削除テスト');
     const postId = widget.currentSettings.posts[0].id;
@@ -216,7 +215,7 @@ describe('TweetWidget', () => {
 
   it('詳細表示中の投稿を削除すると親にフォーカスが移る', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('parent');
     const parentId = widget.currentSettings.posts[0].id;
@@ -229,7 +228,7 @@ describe('TweetWidget', () => {
 
   it('スレッド削除中に表示していた投稿が含まれる場合親にフォーカスが移る', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('grand');
     const grandId = widget.currentSettings.posts[0].id;
@@ -244,7 +243,7 @@ describe('TweetWidget', () => {
 
   it('updatePostPropertyで任意のプロパティが更新される', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('プロパティ更新テスト');
     const postId = widget.currentSettings.posts[0].id;
@@ -254,7 +253,7 @@ describe('TweetWidget', () => {
 
   it('getFilteredPostsでフィルタが反映される', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('フィルタテスト');
     widget.setFilter('all');
@@ -263,7 +262,7 @@ describe('TweetWidget', () => {
 
   it('AIリプライが許可される場合triggerAiReplyで副作用が発生', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('AIリプライテスト');
     const post = widget.currentSettings.posts[0];
@@ -279,7 +278,7 @@ describe('TweetWidget', () => {
 
   it('state未定義時もUIメソッドでエラーにならない', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     widget['store'] = undefined as any;
     expect(() => widget.getFilteredPosts()).toThrow();
@@ -287,7 +286,7 @@ describe('TweetWidget', () => {
 
   it('Command+Enterで投稿できる', async () => {
     const widget = new TweetWidget();
-    const el = widget.create(dummyConfig, dummyApp, dummyPlugin);
+    const el = await widget.create(dummyConfig, dummyApp, dummyPlugin);
     document.body.appendChild(el);
     await new Promise(res => setTimeout(res, 0));
     // textarea取得
@@ -307,7 +306,7 @@ describe('TweetWidget', () => {
 
   it('詳細画面の返信欄でCommand+Enterで返信できる', async () => {
     const widget = new TweetWidget();
-    const el = widget.create(dummyConfig, dummyApp, dummyPlugin);
+    const el = await widget.create(dummyConfig, dummyApp, dummyPlugin);
     document.body.appendChild(el);
     await new Promise(res => setTimeout(res, 0));
     // まず投稿を1件追加
@@ -335,7 +334,7 @@ describe('TweetWidget', () => {
     (dummyApp.vault.create as jest.Mock).mockRejectedValueOnce(new Error('Disk full'));
 
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
 
     await expect(widget.submitPost('投稿テスト')).resolves.not.toThrow();
@@ -347,7 +346,7 @@ describe('TweetWidget', () => {
 
   it('Escキーで編集モードがキャンセルされる', async () => {
     const widget = new TweetWidget();
-    const el = widget.create(dummyConfig, dummyApp, dummyPlugin);
+    const el = await widget.create(dummyConfig, dummyApp, dummyPlugin);
     document.body.appendChild(el);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('編集キャンセルテスト');
@@ -368,7 +367,7 @@ describe('TweetWidget', () => {
 
   it('Escキーで詳細表示がキャンセルされる', async () => {
     const widget = new TweetWidget();
-    const el = widget.create(dummyConfig, dummyApp, dummyPlugin);
+    const el = await widget.create(dummyConfig, dummyApp, dummyPlugin);
     document.body.appendChild(el);
     await new Promise(res => setTimeout(res, 0));
     await widget.submitPost('詳細キャンセルテスト');
@@ -389,7 +388,7 @@ describe('TweetWidget', () => {
 
   it('Markdown特殊文字を含む投稿がエラーなく処理される', async () => {
     const widget = new TweetWidget();
-    widget.create(dummyConfig, dummyApp, dummyPlugin);
+    await widget.create(dummyConfig, dummyApp, dummyPlugin);
     await new Promise(res => setTimeout(res, 0));
     const markdownText = '# heading\n* list\n[link](http://example.com)';
     await expect(widget.submitPost(markdownText)).resolves.not.toThrow();

--- a/__tests__/widgets/tweetWidget.test.ts
+++ b/__tests__/widgets/tweetWidget.test.ts
@@ -88,11 +88,10 @@ describe('TweetWidget', () => {
     expect(widget.currentSettings.posts[0].liked).toBe(before);
   });
 
-  it('tweet-widgetクラスとタイトルが付与される', async () => {
+  it('tweet-widgetクラスが付与される', async () => {
     const widget = new TweetWidget();
     const el = await widget.create(dummyConfig, dummyApp, dummyPlugin);
     expect(el.classList.contains('tweet-widget')).toBe(true);
-    expect(el.textContent).toBe('Loading...');
   });
 
   it('タブ切替でcurrentTabが切り替わりUIが再描画される', async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,7 +122,7 @@ export default class WidgetBoardPlugin extends Plugin {
                 }
                 try {
                     const widgetInstance = new WidgetClass();
-                    const widgetEl = widgetInstance.create(config, this.app, this);
+                    const widgetEl = await widgetInstance.create(config, this.app, this);
                     element.appendChild(widgetEl);
                 } catch (e) {
                     element.createEl('pre', { text: this.t('widgetRenderError', { error: String(e) }) });

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -552,14 +552,14 @@ export class WidgetBoardModal {
                     const WidgetClass = registeredWidgetImplementations.get(widgetConfig.type) as (new () => WidgetImplementation) | undefined;
                     if (WidgetClass) {
                         const isHeavy = ['pomodoro', 'calendar', 'recent-notes'].includes(widgetConfig.type);
-                        const createWidget = () => {
+                        const createWidget = async () => {
                             try {
                                 const widgetInstance = new WidgetClass();
                                 let widgetElement;
                                 if (widgetConfig.type === 'reflection-widget') {
-                                    widgetElement = widgetInstance.create(widgetConfig, this.plugin.app, this.plugin, reflectionPreloadBundle);
+                                    widgetElement = await widgetInstance.create(widgetConfig, this.plugin.app, this.plugin, reflectionPreloadBundle);
                                 } else {
-                                    widgetElement = widgetInstance.create(widgetConfig, this.plugin.app, this.plugin);
+                                    widgetElement = await widgetInstance.create(widgetConfig, this.plugin.app, this.plugin);
                                 }
                                 if (this.isEditMode) {
                                     wrapper.empty();

--- a/src/widgets/memo/index.ts
+++ b/src/widgets/memo/index.ts
@@ -321,13 +321,14 @@ export class MemoWidget implements WidgetImplementation {
                 parent.replaceChild(newDisplayEl, this.memoDisplayEl);
                 this.memoDisplayEl = newDisplayEl;
             }
-            const render = () => {
-                this.renderMemo(this.currentSettings.memoContent)
-                    .then(() => this.applyContainerHeightStyles())
-                    .catch(err => {
-                        console.error(`[${this.config.id}] Error rendering memo in updateMemoEditUI:`, err);
-                        this.applyContainerHeightStyles();
-                    });
+            const render = async () => {
+                try {
+                    await this.renderMemo(this.currentSettings.memoContent);
+                    this.applyContainerHeightStyles();
+                } catch (err) {
+                    console.error(`[${this.config.id}] Error rendering memo in updateMemoEditUI:`, err);
+                    this.applyContainerHeightStyles();
+                }
             };
             if ('requestIdleCallback' in window) {
                 const idleRender = (deadline?: IdleDeadline) => {

--- a/src/widgets/tweetWidget/tweetWidget.ts
+++ b/src/widgets/tweetWidget/tweetWidget.ts
@@ -58,7 +58,7 @@ export class TweetWidget implements WidgetImplementation {
     getReplies(parentId: string): TweetWidgetPost[] { return this.store.getReplies(parentId); }
     getQuotePosts(postId: string): TweetWidgetPost[] { return this.store.getQuotePosts(postId); }
 
-    create(config: WidgetConfig, app: App, plugin: WidgetBoardPlugin): HTMLElement {
+    async create(config: WidgetConfig, app: App, plugin: WidgetBoardPlugin): Promise<HTMLElement> {
         this.config = config;
         this.app = app;
         this.plugin = plugin;
@@ -78,13 +78,12 @@ export class TweetWidget implements WidgetImplementation {
         // 非同期初期化は副作用として行い、UIは一旦ローディング表示
         // jsdom の innerText は textContent を更新しないため textContent を使用する
         this.widgetEl.textContent = 'Loading...';
-        this.repository.load(this.plugin.settings.language || 'ja').then(initialSettings => {
-            this.store = new TweetStore(initialSettings);
-            this.recalculateQuoteCounts();
-            this.ui = new TweetWidgetUI(this, this.widgetEl);
-            this.ui.render();
-            this.startScheduleLoop();
-        });
+        const initialSettings = await this.repository.load(this.plugin.settings.language || 'ja');
+        this.store = new TweetStore(initialSettings);
+        this.recalculateQuoteCounts();
+        this.ui = new TweetWidgetUI(this, this.widgetEl);
+        this.ui.render();
+        this.startScheduleLoop();
 
         this.widgetEl.addEventListener('keydown', this.handleKeyDown);
 

--- a/src/widgets/tweetWidget/tweetWidgetDataViewer.ts
+++ b/src/widgets/tweetWidget/tweetWidgetDataViewer.ts
@@ -213,7 +213,7 @@ export class TweetWidgetDataViewer {
         return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())} ${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
     }
 
-    private copyCsvToClipboard() {
+    private async copyCsvToClipboard() {
         // 現在表示中のカラム・データでCSV生成
         const cols = Array.from(this.allColumns).filter(col => this.visibleColumns.has(col.key));
         const header = cols.map(col => col.label);
@@ -229,14 +229,15 @@ export class TweetWidgetDataViewer {
             });
         });
         const csv = [header, ...rows].map(row => row.map(cell => '"' + cell.replace(/"/g, '""') + '"').join(',')).join('\n');
-        navigator.clipboard.writeText(csv).then(() => {
+        try {
+            await navigator.clipboard.writeText(csv);
             new Notice(t(this.lang, 'copiedAsCsv'));
-        }, () => {
+        } catch {
             new Notice(t(this.lang, 'copyFailed'));
-        });
+        }
     }
 
-    private copyMarkdownToClipboard() {
+    private async copyMarkdownToClipboard() {
         // 現在表示中のカラム・データでMarkdownテーブル生成
         const cols = Array.from(this.allColumns).filter(col => this.visibleColumns.has(col.key));
         const header = cols.map(col => col.label);
@@ -257,11 +258,12 @@ export class TweetWidgetDataViewer {
             '| ' + sep.join(' | ') + ' |',
             ...rows.map(row => '| ' + row.map(cell => cell.replace(/\|/g, '\\|')).join(' | ') + ' |')
         ].join('\n');
-        navigator.clipboard.writeText(md).then(() => {
+        try {
+            await navigator.clipboard.writeText(md);
             new Notice(t(this.lang, 'copiedAsMarkdown'));
-        }, () => {
+        } catch {
             new Notice(t(this.lang, 'copyFailed'));
-        });
+        }
     }
 
     private saveVisibleColumns() {

--- a/src/widgets/tweetWidget/tweetWidgetUI.ts
+++ b/src/widgets/tweetWidget/tweetWidgetUI.ts
@@ -291,7 +291,7 @@ export class TweetWidgetUI {
                 placeholder: this.widget.replyingToParentId ? this.t('replyPlaceholder') : this.t('postPlaceholder') 
             }
         });
-        input.addEventListener('input', () => {
+        input.addEventListener('input', async () => {
             scheduleBatchTweetResize(input);
         });
         requestAnimationFrame(() => {
@@ -302,7 +302,7 @@ export class TweetWidgetUI {
         const ytSuggest = inputArea.createDiv({ cls: 'tweet-youtube-suggest', text: '' });
         ytSuggest.style.display = 'none';
         ytSuggest.textContent = '';
-        input.addEventListener('input', () => {
+        input.addEventListener('input', async () => {
             const val = input.value;
             const url = extractYouTubeUrl(val);
             if (!url) {
@@ -313,11 +313,11 @@ export class TweetWidgetUI {
             ytSuggest.textContent = this.t('fetchingYoutubeTitle');
             ytSuggest.style.display = 'block';
             const currentInput = val;
-            fetchYouTubeTitle(url).then(title => {
-                if (input.value !== currentInput) return;
-                if (title) {
-                    ytSuggest.textContent = this.t('insertYoutubeTitle', { title });
-                    ytSuggest.onclick = () => {
+            const title = await fetchYouTubeTitle(url);
+            if (input.value !== currentInput) return;
+            if (title) {
+                ytSuggest.textContent = this.t('insertYoutubeTitle', { title });
+                ytSuggest.onclick = () => {
                         const insertText = `![${title}](${url})`;
                         // 元のYouTube URL（クエリ付きも含む）を正規表現で検出して置換
                         const urlRegex = /(https?:\/\/(?:www\.|m\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/)[\w-]{11}(?:[?&][^\s]*)?)/;
@@ -330,7 +330,6 @@ export class TweetWidgetUI {
                     ytSuggest.textContent = this.t('fetchYoutubeTitleFailed');
                     ytSuggest.onclick = null;
                 }
-            });
         });
         
         // トグルスイッチ挙動
@@ -1095,7 +1094,7 @@ export class TweetWidgetUI {
         const ytSuggest = inputArea.createDiv({ cls: 'tweet-youtube-suggest', text: '' });
         ytSuggest.style.display = 'none';
         ytSuggest.textContent = '';
-        textarea.addEventListener('input', () => {
+        textarea.addEventListener('input', async () => {
             const val = textarea.value;
             const url = extractYouTubeUrl(val);
             if (!url) {
@@ -1106,8 +1105,8 @@ export class TweetWidgetUI {
             ytSuggest.textContent = this.t('fetchingYoutubeTitle');
             ytSuggest.style.display = 'block';
             const currentInput = val;
-            fetchYouTubeTitle(url).then(title => {
-                if (textarea.value !== currentInput) return;
+            const title = await fetchYouTubeTitle(url);
+            if (textarea.value !== currentInput) return;
                 if (title) {
                     ytSuggest.textContent = this.t('insertYoutubeTitle', { title });
                     ytSuggest.onclick = () => {
@@ -1123,7 +1122,6 @@ export class TweetWidgetUI {
                     ytSuggest.textContent = this.t('fetchYoutubeTitleFailed');
                     ytSuggest.onclick = null;
                 }
-            });
         });
 
         const replyBtn = inputArea.createEl('button', { cls: 'tweet-reply-modal-btn', text: this.t('reply') });
@@ -1216,7 +1214,7 @@ export class TweetWidgetUI {
         const ytSuggest = inputArea.createDiv({ cls: 'tweet-youtube-suggest', text: '' });
         ytSuggest.style.display = 'none';
         ytSuggest.textContent = '';
-        textarea.addEventListener('input', () => {
+        textarea.addEventListener('input', async () => {
             const val = textarea.value;
             const url = extractYouTubeUrl(val);
             if (!url) {
@@ -1227,8 +1225,8 @@ export class TweetWidgetUI {
             ytSuggest.textContent = this.t('fetchingYoutubeTitle');
             ytSuggest.style.display = 'block';
             const currentInput = val;
-            fetchYouTubeTitle(url).then(title => {
-                if (textarea.value !== currentInput) return;
+            const title = await fetchYouTubeTitle(url);
+            if (textarea.value !== currentInput) return;
                 if (title) {
                     ytSuggest.textContent = this.t('insertYoutubeTitle', { title });
                     ytSuggest.onclick = () => {
@@ -1243,7 +1241,6 @@ export class TweetWidgetUI {
                     ytSuggest.textContent = this.t('fetchYoutubeTitleFailed');
                     ytSuggest.onclick = null;
                 }
-            });
         });
 
         const retweetBtn = inputArea.createEl('button', { cls: 'tweet-reply-modal-btn', text: this.t('retweet') });


### PR DESCRIPTION
## Summary
- replace `then` calls with async/await across widgets
- make `TweetWidget.create` async and await repository loading
- use async clipboard helpers in tweet data viewer
- await summary loading in reflection widget UI
- update memo widget rendering helper
- adjust call sites and tests for async create

## Testing
- `npm test` *(fails: ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG)*

------
https://chatgpt.com/codex/tasks/task_e_68577889f5d48320aebc74e4e5eae811