### PR TITLE
Fix Pomodoro CSV log path

### DIFF
--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -46,3 +46,6 @@ export function requestUrl(_opts: any): Promise<any> {
 }
 export class FuzzySuggestModal {}
 export const debounce = (fn: any) => fn;
+export function normalizePath(path: string): string {
+  return path.replace(/\\/g, '/');
+}

--- a/src/widgets/pomodoro/logger.ts
+++ b/src/widgets/pomodoro/logger.ts
@@ -1,4 +1,4 @@
-import { Notice } from 'obsidian';
+import { Notice, normalizePath } from 'obsidian';
 import type { App } from 'obsidian';
 import type WidgetBoardPlugin from '../../main';
 import type { PomodoroExportFormat, SessionLog } from './index';
@@ -25,9 +25,9 @@ export class PomodoroSessionLogger {
     else if (format === 'markdown') ext = 'md';
     else return;
 
-    const pluginFolder = this.app.vault.configDir + '/plugins/' + this.plugin.manifest.id;
-    const logsFolder = pluginFolder + '/logs';
-    const filePath = logsFolder + `/pomodoro-log.${ext}`;
+    const pluginFolder = normalizePath(`${this.app.vault.configDir}/plugins/${this.plugin.manifest.id}`);
+    const logsFolder = normalizePath(`${pluginFolder}/logs`);
+    const filePath = normalizePath(`${logsFolder}/pomodoro-log.${ext}`);
     let allLogs: SessionLog[] = [];
     try {
       const logsFolderExists = await this.app.vault.adapter.exists(logsFolder);


### PR DESCRIPTION
## Summary
- fix Pomodoro log paths by normalizing them
- add `normalizePath` mock for tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857b5a580b483209172c1cc43bc2361